### PR TITLE
Add development workflow, human interactions doc, ADR structure, and CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  typecheck:
+    name: Type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect package.json
+        id: pkg
+        run: echo "exists=$(test -f package.json && echo true || echo false)" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-node@v4
+        if: steps.pkg.outputs.exists == 'true'
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+        if: steps.pkg.outputs.exists == 'true'
+      - run: npm run typecheck
+        if: steps.pkg.outputs.exists == 'true'
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect package.json
+        id: pkg
+        run: echo "exists=$(test -f package.json && echo true || echo false)" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-node@v4
+        if: steps.pkg.outputs.exists == 'true'
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+        if: steps.pkg.outputs.exists == 'true'
+      - run: npm run lint
+        if: steps.pkg.outputs.exists == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,11 @@ The full design specification is at `docs/design-specification.md` and is the au
 
 ## Project status
 
-The project is in initial development. The design spec is complete; no source code exists yet. This CLAUDE.md should be updated with build/test commands once the project is scaffolded.
+The project is in initial development (Phase 0 not yet started). The design spec is complete; no source code exists yet. This CLAUDE.md will be updated with build/test commands in Phase 0.
+
+## Development workflow
+
+See `docs/workflow.md` for the full workflow. See `docs/human-interactions.md` for every human approval gate. ADRs live in `docs/adr/`. Planning session summaries live in `docs/sessions/`.
 
 ## Architecture
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jim Casey
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/adr/001-mit-license.md
+++ b/docs/adr/001-mit-license.md
@@ -1,0 +1,25 @@
+# ADR 001 — MIT License
+
+**Status:** Accepted
+**Date:** 2026-04-28
+**Decider:** Jim Casey
+
+## Decision
+
+Jackdaw is released under the MIT License. See `LICENSE` in the repository root.
+
+## Context
+
+The project needed a license before any code was written. Three options were considered: MIT, AGPLv3, and Apache 2.0.
+
+## Rationale
+
+**MIT was chosen because:**
+- The Obsidian plugin ecosystem skews MIT. Contributors and company-employed developers can use or contribute to MIT code without legal review.
+- Jackdaw depends on Obsidian (closed-source) and GitHub's API (third-party SaaS). AGPL's copyleft and network-use protections are largely theoretical — any fork would still depend on the same closed services, limiting the practical protection AGPL would offer.
+- Apache 2.0's explicit patent grant adds little value given the plugin's implementation surface (no novel algorithms, no hardware interaction, no patentable mechanisms).
+- MIT has the lowest friction for adoption and contribution, which matters more than fork protection in this ecosystem.
+
+## Consequences
+
+Anyone may fork, embed, or commercialize Jackdaw without restriction. A closed-source commercial fork is theoretically possible. This is considered an acceptable risk given the ecosystem norms and the plugin's dependency on closed platforms.

--- a/docs/design-specification.md
+++ b/docs/design-specification.md
@@ -565,26 +565,11 @@ Captured here so they're not lost.
 
 ## 13. Licensing
 
-User has no preference and typically defaults to MIT. Tradeoffs:
+**Decision: MIT License.**
 
-**MIT**
-- *Pro:* Maximum permissiveness. Anyone can fork, embed, or commercialize. Best for adoption and contribution from people who work at companies with strict policies against AGPL/copyleft code (this is a real, common issue).
-- *Pro:* Compatible with virtually any other license. The Obsidian plugin ecosystem skews MIT/Apache, so contributors won't blink.
-- *Con:* A future commercial competitor could fork the plugin, add proprietary features (e.g. "GitHub Sync Pro for $5/mo"), and the user has no recourse.
+Jackdaw is released under the MIT License. See `LICENSE` in the repository root.
 
-**AGPLv3** (what `silvanocerza/github-gitless-sync` uses)
-- *Pro:* Forks must remain open-source, and the network-use clause means even SaaS-style hosting is covered. Discourages closed-source competitive forks.
-- *Con:* Many companies (and some individual contributors) outright refuse to touch AGPL code. Reduces contribution surface.
-- *Con:* For a client-side Obsidian plugin, the network-use clause is mostly theoretical — the plugin runs on the user's device, not on a service.
-- *Con:* Some Obsidian users may be wary of installing AGPL plugins into a vault they treat as a creative work, though this is more vibe than legal risk.
-
-**Apache 2.0**
-- *Pro:* Same permissiveness as MIT but with explicit patent grant — useful protection if any of the plugin's mechanisms are patentable (probably none are, but it's free defense).
-- *Con:* Slightly more text to include. Marginally less common in the Obsidian ecosystem than MIT.
-
-**Recommendation:** MIT. The user's default is the right default here. The AGPL "no closed-source forks" benefit is small for a plugin that depends on Obsidian (which is itself closed-source) and uses GitHub's API (a third-party SaaS). The MIT downside (commercial fork risk) is theoretically possible but rare in this ecosystem.
-
-If the user wants slightly stronger IP protection without giving up adoption, Apache 2.0 is the conservative alternative.
+Rationale: maximum permissiveness with zero friction for contributors. The Obsidian plugin ecosystem skews MIT, AGPL's network-use clause is largely theoretical for a client-side plugin, and Apache 2.0's patent grant adds little value given the plugin's implementation surface.
 
 ---
 

--- a/docs/human-interactions.md
+++ b/docs/human-interactions.md
@@ -1,0 +1,126 @@
+# Human Interactions
+
+Every point in the development workflow that requires a human decision or action.
+
+---
+
+## Initial setup
+
+**Trigger:** This document is first created.
+
+**Action:** In GitHub repository settings, create the following milestones and configure label colors:
+
+Milestones to create (no due dates required):
+- `Phase 0 — Scaffold`
+- `Phase 1 — Core libs`
+- `Phase 2 — Sync engine`
+- `Phase 3 — UI`
+- `Phase 4 — First-sync + conflicts`
+- `Phase 5 — BRAT release`
+
+Labels to configure (colors are suggestions):
+- `type: feature` — blue (`#0075ca`)
+- `type: bug` — red (`#d73a4a`)
+- `type: chore` — gray (`#e4e669`)
+- `type: docs` — light gray (`#cfd3d7`)
+- `phase: 0` through `phase: 5` — yellow gradient
+- `needs: planning` — purple (`#7057ff`)
+- `needs: review` — orange (`#e99695`)
+
+Assign existing issues to the Phase 0 milestone and apply appropriate labels.
+
+---
+
+## Phase planning
+
+**Trigger:** Start of each phase, or an issue is labeled `needs: planning`.
+
+**Action:**
+1. Start a Claude Code session and request a planning session for the phase.
+2. Read the session summary saved to `docs/sessions/`.
+3. Review each created issue: title, description, acceptance criteria.
+4. Edit, close, or add issues as needed.
+5. Assign the correct phase label and milestone to each issue.
+6. Signal readiness — work does not start until you confirm issues are ready.
+
+---
+
+## ADR review
+
+**Trigger:** Claude opens a PR containing a new `docs/adr/NNN-<slug>.md`.
+
+**Action:** Read the ADR. Approve if the decision is correct; request changes or reopen discussion if not. Merged ADRs are immutable — if you have doubts, surface them before merging.
+
+---
+
+## Pull request review
+
+**Trigger:** Implementation is complete on a branch. `/ultrareview` has run.
+
+**Action:**
+1. Read the `/ultrareview` output.
+2. Review the diff.
+3. Approve and squash-merge, or request changes.
+
+Do not merge without `/ultrareview` completing. If ultrareview raises a concern you're unsure about, ask Claude to explain before merging.
+
+---
+
+## Phase gate
+
+**Trigger:** All issues in a phase milestone are closed.
+
+**Action:** Confirm the phase is done before planning the next one. For Phase 2 and later, smoke-test the plugin in Obsidian desktop before sign-off. Sign-off is explicit ("start Phase N planning") — phases do not advance automatically.
+
+---
+
+## iOS manual testing (Phase 5 gate)
+
+**Trigger:** Phase 5 milestone begins.
+
+**Action:** Execute every scenario in §11.3 of `docs/design-specification.md` on a **physical iPhone**. This cannot be delegated to Claude or automated.
+
+Scenarios (§11.3):
+- Install via BRAT; first-sync against a real (small) test vault and test repo
+- Sync after editing on iOS only (push-only path)
+- Sync after editing remotely only (pull-only path)
+- Sync with a conflict; resolve via mobile UI
+- Force-quit Obsidian mid-sync; reopen; verify state recovery via `.tmp` path
+- Upload a 25 MB attachment; verify size-limit message appears
+- Toggle airplane mode mid-sync; verify failure mode and message
+
+Record pass/fail for each scenario. Phase 5 does not close until all pass.
+
+---
+
+## Obsidian Sync coexistence testing (Phase 5 gate)
+
+**Trigger:** iOS manual testing complete.
+
+**Action:** Execute every scenario in §11.4 using two real devices both running Obsidian Sync and the plugin:
+
+- Edit on device A → sync to GitHub from A → wait for Obsidian Sync to propagate → sync from B → expect no-op, no conflict
+- Edit on device A → sync from A → sync from B *before* Obsidian Sync propagates (stale `sync-state.json` on B) → expect staleness detection (§4.4 case 3) and silent recovery
+- Edit on both devices + agent edit on GitHub → sync from one device → verify conflict UI shows the right conflicts and resolution applies cleanly
+
+---
+
+## BRAT release
+
+**Trigger:** All Phase 5 acceptance criteria (§15 of `docs/design-specification.md`) are met.
+
+**Action:**
+1. Create a GitHub Release with a semver tag — e.g., `0.1.0`. No `v` prefix (required by the Obsidian registry, future-proofing now).
+2. Attach build artifacts (`main.js`, `manifest.json`, `styles.css` if present).
+3. Post to the Obsidian community forum and/or Discord to recruit BRAT testers.
+
+---
+
+## Community registry submission (v1.1, future)
+
+**Trigger:** Two consecutive weeks with no high-severity bug reports after BRAT release, and all registry prerequisites from §14 of the design spec are met.
+
+**Action:**
+1. Submit a PR to the [obsidian-releases](https://github.com/obsidianmd/obsidian-releases) repository.
+2. Monitor review; respond to feedback.
+3. See §14 of `docs/design-specification.md` for constraints (no "obsidian" in ID, no version `v` prefix, README requirements).

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,140 @@
+# Development Workflow
+
+## Overview
+
+Jackdaw is developed incrementally through Claude Code. Claude handles implementation and plays product/design roles during planning. The human approves at every gate.
+
+See `docs/human-interactions.md` for every point that requires human input.
+
+---
+
+## Branch strategy
+
+| Branch | Purpose |
+|---|---|
+| `main` | Always releasable. Nothing merges without a PR. |
+| `claude/<slug>` | All work branches. One issue per branch. Short-lived. |
+
+All PRs are **squash-merged** into `main`. This keeps history readable and one-to-one with issues.
+
+---
+
+## Issue tracking
+
+GitHub Issues + Milestones. No Projects board.
+
+### Labels
+
+| Label | Meaning |
+|---|---|
+| `type: feature` | New capability |
+| `type: bug` | Something broken |
+| `type: chore` | Scaffolding, tooling, CI |
+| `type: docs` | Documentation only |
+| `phase: 0` … `phase: 5` | Which build phase |
+| `needs: planning` | Requires a planning session before work starts |
+| `needs: review` | AI review requested |
+
+### Milestones
+
+| Milestone | Contents |
+|---|---|
+| Phase 0 — Scaffold | npm project, build config, `manifest.json`, stub `main.ts`, CI |
+| Phase 1 — Core libs | `github-client.ts`, `state-store.ts`, `logger.ts` |
+| Phase 2 — Sync engine | `sync-engine.ts`, classifier, pull, push |
+| Phase 3 — UI | Settings tab, ribbon, status bar, error notices |
+| Phase 4 — First-sync + conflicts | First-sync modal, conflict resolution modal |
+| Phase 5 — BRAT release | Tests, iOS validation, Obsidian Sync coexistence, README, release |
+
+**Rule:** Only populate issues for the current phase and the next one. Don't create issues for phases beyond that — the spec will have evolved by then.
+
+---
+
+## Planning sessions
+
+Before each phase (or when an issue is labeled `needs: planning`), run a planning session where Claude plays two roles:
+
+- **Product**: Does this feature serve the primary use case (§1.3 of the spec)? Is the scope right? What's the acceptance criterion?
+- **Design**: How does this present to the user? What are the edge-case UX states (loading, error, conflict)? Does it work on a phone screen?
+
+**Output of a planning session:**
+1. A set of GitHub Issues with descriptions and acceptance criteria.
+2. A session summary saved to `docs/sessions/YYYY-MM-DD-<topic>.md`.
+
+Planning sessions are triggered when:
+- Starting a new phase
+- An issue is labeled `needs: planning`
+- A design decision in the spec needs to be resolved before coding
+
+---
+
+## Development loop (per issue)
+
+```
+Planning session → GitHub Issues created
+        ↓
+Pick an issue
+        ↓
+Claude Code: implement on claude/<slug> branch
+        ↓
+PR opened (title references issue; body closes #N)
+        ↓
+/ultrareview runs
+        ↓
+Human reviews + approves
+        ↓
+Squash merge → issue closes automatically
+```
+
+For UI-facing changes, the planning session also doubles as a design review: Claude proposes the UX flow before any code is written.
+
+---
+
+## AI code review
+
+Run `/ultrareview` on every PR before merging.
+
+Focus areas by phase:
+
+| Phase | Review focus |
+|---|---|
+| 0–1 | Correctness, constraint compliance (`requestUrl` not `fetch`, vault I/O only, PAT never logged) |
+| 2 | Classifier matrix coverage (every cell of §5.5), error handling, retry logic |
+| 3+ | Mobile layout, iOS-specific behavior, accessibility |
+
+---
+
+## CI
+
+GitHub Actions runs lint and type-check on every PR and on pushes to `main`. Configuration lives at `.github/workflows/ci.yml`. The specific npm scripts (`typecheck`, `lint`) are wired up in Phase 0.
+
+CI must pass before a PR can be merged.
+
+---
+
+## ADRs
+
+Significant architectural or product decisions get a record in `docs/adr/NNN-<slug>.md`.
+
+- Claude drafts the ADR during the planning session or at decision time.
+- Human approves via PR review.
+- Merged ADRs are **immutable** — new decisions supersede rather than edit.
+
+Template: see `docs/adr/001-mit-license.md`.
+
+---
+
+## Phase summary
+
+```
+Phase 0  Scaffold          npm, build, manifest.json, stub main.ts, CI
+Phase 1  Core libs         github-client.ts, state-store.ts, logger.ts
+Phase 2  Sync engine       classifier, pull, push
+Phase 3  UI                settings tab, ribbon, status bar
+Phase 4  First-sync+conf   first-sync modal, conflict resolution modal
+Phase 5  BRAT release      tests, iOS, Obsidian Sync coexistence, README, ship
+```
+
+---
+
+Authoritative spec: `docs/design-specification.md`


### PR DESCRIPTION
- LICENSE file (MIT, copyright Jim Casey 2026)
- docs/workflow.md: authoritative workflow reference (branches, issues,
  planning sessions, dev loop, review, CI, ADRs, phase summary)
- docs/human-interactions.md: every human approval gate from planning
  through BRAT release and registry submission
- docs/adr/001-mit-license.md: first ADR capturing the MIT license decision
- docs/sessions/: directory for planning session summaries
- .github/workflows/ci.yml: lint + typecheck CI, gracefully skips until
  Phase 0 scaffold adds package.json
- CLAUDE.md: updated project status and added workflow pointers

https://claude.ai/code/session_01R9N2H7R6jGkFrGW8YSjEpQ