### PR TITLE
Add ESLint rules for no-any, no-unused-vars, and no-fetch (#5)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,5 +5,16 @@
   "extends": ["plugin:@typescript-eslint/recommended"],
   "env": {
     "browser": true
+  },
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    "no-restricted-globals": [
+      "error",
+      {
+        "name": "fetch",
+        "message": "Use requestUrl from 'obsidian' instead of fetch."
+      }
+    ]
   }
 }


### PR DESCRIPTION
Enforces the three rules required by issue #5: @typescript-eslint/no-explicit-any
as error, @typescript-eslint/no-unused-vars as error (with _-prefix escape), and
no-restricted-globals banning fetch in favour of requestUrl.

https://claude.ai/code/session_01CHpmeCLHunBLjyxea85ed1