### PR TITLE
Add PR title/description guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,11 @@ The project is in initial development (Phase 0 not yet started). The design spec
 
 See `docs/workflow.md` for the full workflow. See `docs/human-interactions.md` for every human approval gate. ADRs live in `docs/adr/`. Planning session summaries live in `docs/sessions/`.
 
+## Pull requests
+
+- Keep PR titles short and descriptive; do not include issue references in the title.
+- Reference issues in the PR description using `Closes #N` (or `Fixes #N`). GitHub automatically closes the linked issue on squash-merge even when the keyword is in the description rather than the title.
+
 ## Architecture
 
 Six modules (see §3 of the design spec for the ASCII diagram):


### PR DESCRIPTION
Issue references belong in the description (Closes #N), not the title.
GitHub still auto-closes issues on squash-merge when the keyword is in the description.

https://claude.ai/code/session_01DeNMAFL6YnwnhoSSrVyfbk