### PR TITLE
Add build commands, dev setup, and expanded README docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,24 @@ The full design specification is at `docs/design-specification.md` and is the au
 
 ## Project status
 
-The project is in initial development (Phase 0 not yet started). The design spec is complete; no source code exists yet. This CLAUDE.md will be updated with build/test commands in Phase 0.
+Phase 0 (scaffold) is complete. Phase 1 (core implementation) is next.
+
+## Build commands
+
+```sh
+npm install       # install dependencies
+npm run build     # production build → main.js
+npm run dev       # watch mode (rebuilds on save)
+npm run typecheck # TypeScript type check without emitting
+npm run lint      # ESLint over src/
+```
+
+## Loading in Obsidian
+
+1. Clone (or symlink) this repo into `<your-vault>/.obsidian/plugins/jackdaw/`.
+2. Run `npm install && npm run build` to produce `main.js`.
+3. In Obsidian → Settings → Community plugins, disable Safe mode and enable **Jackdaw**.
+4. During development, run `npm run dev` for watch mode, then use **Reload app without saving** (Ctrl/Cmd+P) after each rebuild.
 
 ## Development workflow
 

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ Six modules make up the plugin:
 - [Design Specification](docs/design-specification.md)
 - [Workflow](docs/workflow.md)
 - [Human Interaction Gates](docs/human-interactions.md)
-- [ADR: MIT License](docs/adr/001-mit-license.md)
+- [ADRs](docs/adr/)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,37 @@
 
 A manual, bidirectional, one-button synchronizer between an Obsidian vault and a single branch of a single GitHub repository.
 
+## Getting started
+
+**Prerequisites:** Node.js 20+, npm
+
+```sh
+git clone https://github.com/jimcasey/jackdaw.git
+cd jackdaw
+npm install
+npm run build     # produces main.js
+```
+
+**Load in Obsidian:**
+
+1. Copy (or symlink) this directory into `<your-vault>/.obsidian/plugins/jackdaw/`.
+2. In Obsidian → Settings → Community plugins, disable Safe mode and enable **Jackdaw**.
+3. For development, run `npm run dev` for watch mode and use **Reload app without saving** (Ctrl/Cmd+P) after each rebuild.
+
+## Architecture
+
+Six modules make up the plugin:
+
+- **`src/main.ts`** — Plugin entry point; registers the ribbon icon and sync command.
+- **`src/github-client.ts`** — GitHub REST API wrapper using Obsidian's `requestUrl`; handles auth, rate limits, and base64 encoding.
+- **`src/sync-engine.ts`** — Core sync state machine: pre-flight → scan → classify → pull → push → save state.
+- **`src/state-store.ts`** — Owns `sync-state.json` (file hashes and blob SHAs). Atomic writes via temp-file rename.
+- **`src/logger.ts`** — JSONL log with automatic 1 MB rotation. Never logs secrets or file contents.
+- **`src/ui/`** — Settings tab, ribbon icon, status bar, and conflict-resolution modals.
+
 ## Docs
 
 - [Design Specification](docs/design-specification.md)
+- [Workflow](docs/workflow.md)
+- [Human Interaction Gates](docs/human-interactions.md)
+- [ADR: MIT License](docs/adr/001-mit-license.md)


### PR DESCRIPTION
Updates CLAUDE.md with build commands and Obsidian loading instructions,
advances project status to Phase 1, and expands README with getting started
guide, architecture overview, and full docs links.

Closes #6
Closes #15

https://claude.ai/code/session_01BVeg8jBsweB6MvmLMaF3ja