### PR TITLE
Add StateStore with atomic writes and .tmp recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ If the session opens with a message that is solely an issue number (e.g. `#40` o
 ## Pull requests
 
 - Keep PR titles short and descriptive; do not include issue references in the title.
-- Reference issues in the PR description using `Closes #N` (or `Fixes #N`). GitHub automatically closes the linked issue on squash-merge even when the keyword is in the description rather than the title.
+- **Always** include `Closes #N` (or `Fixes #N`) in the PR description body — never in the title. GitHub auto-closes the linked issue on squash-merge only when the keyword appears in the description. This is required for every PR that resolves an issue; do not skip it.
 
 ## Architecture
 

--- a/src/state-store.test.ts
+++ b/src/state-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, type Mock } from 'vitest';
-import { StateStore, SCHEMA_VERSION, type SyncState, type Logger, type StateAdapter } from './state-store';
+import { StateStore, type SyncState, type Logger, type StateAdapter } from './state-store';
 
 const PLUGIN_FOLDER = '.obsidian/plugins/jackdaw';
 const CANONICAL = `${PLUGIN_FOLDER}/sync-state.json`;
@@ -31,8 +31,8 @@ function makeLogger(): Logger & { warns: string[]; infos: string[] } {
 	return {
 		warns,
 		infos,
-		warn(event: string) { warns.push(event); },
-		info(event: string) { infos.push(event); },
+		warn(event: string) { warns.push(event); return Promise.resolve(); },
+		info(event: string) { infos.push(event); return Promise.resolve(); },
 	};
 }
 
@@ -118,6 +118,36 @@ describe('StateStore', () => {
 		expect(logger.infos).toContain('state.recover');
 	});
 
+	test('recovery: read error on .tmp returns null and logs state.corrupt', async () => {
+		const adapter = makeAdapter();
+		adapter.exists.mockImplementation((path: string) =>
+			Promise.resolve(path === TMP),
+		);
+		adapter.read.mockRejectedValue(new Error('fs error'));
+
+		const logger = makeLogger();
+		const store = new StateStore(asAdapter(adapter), PLUGIN_FOLDER, logger);
+		expect(await store.load()).toBeNull();
+		expect(logger.warns).toContain('state.corrupt');
+	});
+
+	test('both files exist: reads canonical and ignores .tmp', async () => {
+		const adapter = makeAdapter();
+		const state = makeState();
+		adapter.exists.mockResolvedValue(true);
+		adapter.read.mockImplementation((path: string) => {
+			if (path === CANONICAL) return Promise.resolve(JSON.stringify(state));
+			return Promise.reject(new Error('should not read .tmp'));
+		});
+
+		const store = new StateStore(asAdapter(adapter), PLUGIN_FOLDER, makeLogger());
+		const loaded = await store.load();
+
+		expect(loaded).toEqual(state);
+		expect(adapter.read).toHaveBeenCalledWith(CANONICAL);
+		expect(adapter.read).not.toHaveBeenCalledWith(TMP);
+	});
+
 	test('corrupt JSON: load() returns null and logs state.corrupt', async () => {
 		const adapter = makeAdapter();
 		adapter.exists.mockImplementation((path: string) =>
@@ -143,9 +173,5 @@ describe('StateStore', () => {
 		const store = new StateStore(asAdapter(adapter), PLUGIN_FOLDER, logger);
 		expect(await store.load()).toBeNull();
 		expect(logger.warns).toContain('state.schema-mismatch');
-	});
-
-	test('SCHEMA_VERSION is 1', () => {
-		expect(SCHEMA_VERSION).toBe(1);
 	});
 });

--- a/src/state-store.test.ts
+++ b/src/state-store.test.ts
@@ -1,0 +1,151 @@
+import { describe, test, expect, vi, type Mock } from 'vitest';
+import { StateStore, SCHEMA_VERSION, type SyncState, type Logger, type StateAdapter } from './state-store';
+
+const PLUGIN_FOLDER = '.obsidian/plugins/jackdaw';
+const CANONICAL = `${PLUGIN_FOLDER}/sync-state.json`;
+const TMP = `${PLUGIN_FOLDER}/sync-state.json.tmp`;
+
+interface MockAdapter {
+	exists: Mock;
+	read: Mock;
+	write: Mock;
+	rename: Mock;
+}
+
+function makeAdapter(): MockAdapter {
+	return {
+		exists: vi.fn(),
+		read: vi.fn(),
+		write: vi.fn().mockResolvedValue(undefined),
+		rename: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+function asAdapter(mock: MockAdapter): StateAdapter {
+	return mock as unknown as StateAdapter;
+}
+
+function makeLogger(): Logger & { warns: string[]; infos: string[] } {
+	const warns: string[] = [];
+	const infos: string[] = [];
+	return {
+		warns,
+		infos,
+		warn(event: string) { warns.push(event); },
+		info(event: string) { infos.push(event); },
+	};
+}
+
+function makeState(): SyncState {
+	return {
+		schemaVersion: 1,
+		lastSyncCommitSha: 'abc123deadbeef',
+		lastSyncAt: '2026-04-28T00:00:00.000Z',
+		files: {
+			'notes/hello.md': {
+				path: 'notes/hello.md',
+				blobSha: 'deadbeef1234',
+				contentHash: 'sha256ofcontent',
+				size: 100,
+				isBinary: false,
+			},
+		},
+	};
+}
+
+describe('StateStore', () => {
+	test('absence: load() returns null when neither file exists', async () => {
+		const adapter = makeAdapter();
+		adapter.exists.mockResolvedValue(false);
+		const store = new StateStore(asAdapter(adapter), PLUGIN_FOLDER, makeLogger());
+		expect(await store.load()).toBeNull();
+	});
+
+	test('round-trip: save() then load() returns an equal state', async () => {
+		const adapter = makeAdapter();
+		let stored = '';
+		adapter.write.mockImplementation((_path: string, content: string) => {
+			stored = content;
+			return Promise.resolve();
+		});
+		adapter.exists.mockImplementation((path: string) =>
+			Promise.resolve(path === CANONICAL),
+		);
+		adapter.read.mockImplementation(() => Promise.resolve(stored));
+
+		const store = new StateStore(asAdapter(adapter), PLUGIN_FOLDER, makeLogger());
+		const state = makeState();
+		await store.save(state);
+		const loaded = await store.load();
+		expect(loaded).toEqual(state);
+	});
+
+	test('save: writes to .tmp before rename', async () => {
+		const adapter = makeAdapter();
+		const callOrder: string[] = [];
+		adapter.write.mockImplementation((path: string) => {
+			callOrder.push(`write:${path}`);
+			return Promise.resolve();
+		});
+		adapter.rename.mockImplementation((from: string, to: string) => {
+			callOrder.push(`rename:${from}->${to}`);
+			return Promise.resolve();
+		});
+
+		const store = new StateStore(asAdapter(adapter), PLUGIN_FOLDER, makeLogger());
+		await store.save(makeState());
+
+		expect(callOrder).toEqual([
+			`write:${TMP}`,
+			`rename:${TMP}->${CANONICAL}`,
+		]);
+	});
+
+	test('recovery: .tmp exists but canonical does not — loads tmp, emits state.recover, renames', async () => {
+		const adapter = makeAdapter();
+		const state = makeState();
+		adapter.exists.mockImplementation((path: string) =>
+			Promise.resolve(path === TMP),
+		);
+		adapter.read.mockResolvedValue(JSON.stringify(state));
+
+		const logger = makeLogger();
+		const store = new StateStore(asAdapter(adapter), PLUGIN_FOLDER, logger);
+		const loaded = await store.load();
+
+		expect(loaded).toEqual(state);
+		expect(adapter.rename).toHaveBeenCalledWith(TMP, CANONICAL);
+		expect(logger.infos).toContain('state.recover');
+	});
+
+	test('corrupt JSON: load() returns null and logs state.corrupt', async () => {
+		const adapter = makeAdapter();
+		adapter.exists.mockImplementation((path: string) =>
+			Promise.resolve(path === CANONICAL),
+		);
+		adapter.read.mockResolvedValue('{ not valid json !!!');
+
+		const logger = makeLogger();
+		const store = new StateStore(asAdapter(adapter), PLUGIN_FOLDER, logger);
+		expect(await store.load()).toBeNull();
+		expect(logger.warns).toContain('state.corrupt');
+	});
+
+	test('schema mismatch: load() returns null and logs state.schema-mismatch', async () => {
+		const adapter = makeAdapter();
+		const badState = { ...makeState(), schemaVersion: 99 };
+		adapter.exists.mockImplementation((path: string) =>
+			Promise.resolve(path === CANONICAL),
+		);
+		adapter.read.mockResolvedValue(JSON.stringify(badState));
+
+		const logger = makeLogger();
+		const store = new StateStore(asAdapter(adapter), PLUGIN_FOLDER, logger);
+		expect(await store.load()).toBeNull();
+		expect(logger.warns).toContain('state.schema-mismatch');
+	});
+
+	test('SCHEMA_VERSION is 1', () => {
+		expect(SCHEMA_VERSION).toBe(1);
+	});
+});

--- a/src/state-store.ts
+++ b/src/state-store.ts
@@ -1,0 +1,91 @@
+export interface SyncedFileRecord {
+	path: string;
+	blobSha: string;
+	contentHash: string;
+	size: number;
+	isBinary: boolean;
+}
+
+export interface SyncState {
+	schemaVersion: 1;
+	lastSyncCommitSha: string | null;
+	lastSyncAt: string;
+	files: Record<string, SyncedFileRecord>;
+}
+
+export const SCHEMA_VERSION = 1 as const;
+
+export interface Logger {
+	info(event: string, data?: Record<string, unknown>): void;
+	warn(event: string, data?: Record<string, unknown>): void;
+}
+
+export interface StateAdapter {
+	exists(path: string): Promise<boolean>;
+	read(path: string): Promise<string>;
+	write(path: string, data: string): Promise<void>;
+	rename(from: string, to: string): Promise<void>;
+}
+
+export class StateStore {
+	private readonly canonicalPath: string;
+	private readonly tmpPath: string;
+
+	constructor(
+		private readonly adapter: StateAdapter,
+		pluginFolder: string,
+		private readonly logger: Logger,
+		private readonly pretty = false,
+	) {
+		this.canonicalPath = `${pluginFolder}/sync-state.json`;
+		this.tmpPath = `${pluginFolder}/sync-state.json.tmp`;
+	}
+
+	async load(): Promise<SyncState | null> {
+		const canonicalExists = await this.adapter.exists(this.canonicalPath);
+		const tmpExists = await this.adapter.exists(this.tmpPath);
+
+		if (!canonicalExists && !tmpExists) {
+			return null;
+		}
+
+		let raw: string;
+		if (!canonicalExists && tmpExists) {
+			raw = await this.adapter.read(this.tmpPath);
+			this.logger.info('state.recover', { path: this.tmpPath });
+			await this.adapter.rename(this.tmpPath, this.canonicalPath);
+		} else {
+			raw = await this.adapter.read(this.canonicalPath);
+		}
+
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(raw);
+		} catch {
+			this.logger.warn('state.corrupt', { reason: 'invalid-json' });
+			return null;
+		}
+
+		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+			this.logger.warn('state.corrupt', { reason: 'not-an-object' });
+			return null;
+		}
+
+		const obj = parsed as Record<string, unknown>;
+		if (obj['schemaVersion'] !== SCHEMA_VERSION) {
+			this.logger.warn('state.schema-mismatch', {
+				expected: SCHEMA_VERSION,
+				found: obj['schemaVersion'],
+			});
+			return null;
+		}
+
+		return obj as unknown as SyncState;
+	}
+
+	async save(state: SyncState): Promise<void> {
+		const json = this.pretty ? JSON.stringify(state, null, 2) : JSON.stringify(state);
+		await this.adapter.write(this.tmpPath, json);
+		await this.adapter.rename(this.tmpPath, this.canonicalPath);
+	}
+}

--- a/src/state-store.ts
+++ b/src/state-store.ts
@@ -16,8 +16,8 @@ export interface SyncState {
 export const SCHEMA_VERSION = 1 as const;
 
 export interface Logger {
-	info(event: string, data?: Record<string, unknown>): void;
-	warn(event: string, data?: Record<string, unknown>): void;
+	info(event: string, data?: Record<string, unknown>): Promise<void>;
+	warn(event: string, data?: Record<string, unknown>): Promise<void>;
 }
 
 export interface StateAdapter {
@@ -51,29 +51,39 @@ export class StateStore {
 
 		let raw: string;
 		if (!canonicalExists && tmpExists) {
-			raw = await this.adapter.read(this.tmpPath);
-			this.logger.info('state.recover', { path: this.tmpPath });
+			try {
+				raw = await this.adapter.read(this.tmpPath);
+			} catch {
+				await this.logger.warn('state.corrupt', { reason: 'read-error' });
+				return null;
+			}
+			await this.logger.info('state.recover', { path: this.tmpPath });
 			await this.adapter.rename(this.tmpPath, this.canonicalPath);
 		} else {
-			raw = await this.adapter.read(this.canonicalPath);
+			try {
+				raw = await this.adapter.read(this.canonicalPath);
+			} catch {
+				await this.logger.warn('state.corrupt', { reason: 'read-error' });
+				return null;
+			}
 		}
 
 		let parsed: unknown;
 		try {
 			parsed = JSON.parse(raw);
 		} catch {
-			this.logger.warn('state.corrupt', { reason: 'invalid-json' });
+			await this.logger.warn('state.corrupt', { reason: 'invalid-json' });
 			return null;
 		}
 
 		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-			this.logger.warn('state.corrupt', { reason: 'not-an-object' });
+			await this.logger.warn('state.corrupt', { reason: 'not-an-object' });
 			return null;
 		}
 
 		const obj = parsed as Record<string, unknown>;
 		if (obj['schemaVersion'] !== SCHEMA_VERSION) {
-			this.logger.warn('state.schema-mismatch', {
+			await this.logger.warn('state.schema-mismatch', {
 				expected: SCHEMA_VERSION,
 				found: obj['schemaVersion'],
 			});


### PR DESCRIPTION
Implements `src/state-store.ts` per §4 of the design spec: `SyncedFileRecord` and `SyncState` types, `SCHEMA_VERSION` constant, and `StateStore` class with `load()`/`save()` methods. `save()` uses temp-file-and-rename atomicity; `load()` recovers from `.tmp` when canonical is missing, handles corrupt JSON and schema mismatches by returning `null` with structured log events. `Logger` interface matches the merged `Logger` class so the two are structurally compatible.

Closes #22

https://claude.ai/code/session_01SHKWAzz1oqR2F2NjLDvpB2