### PR TITLE
Add GitHub client transport layer (src/github-client.ts)

### DIFF
--- a/src/github-client.test.ts
+++ b/src/github-client.test.ts
@@ -1,0 +1,298 @@
+import { vi, describe, test, expect, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+
+vi.mock('obsidian', () => ({
+	requestUrl: vi.fn(),
+}));
+
+import { requestUrl } from 'obsidian';
+import type { RequestUrlResponse } from 'obsidian';
+import {
+	GitHubClient,
+	GHAuthError,
+	GHNotFoundError,
+	GHRateLimitError,
+	GHFastForwardError,
+	GHNetworkError,
+	GHServerError,
+	encodeBase64Chunked,
+} from './github-client';
+
+const mockRequestUrl = requestUrl as Mock;
+
+// Access private `request` without `any`
+interface TestableClient {
+	request(
+		method: string,
+		path: string,
+		options?: { accept?: string; body?: unknown },
+	): Promise<unknown>;
+}
+
+function call(
+	client: GitHubClient,
+	method: string,
+	path: string,
+	options?: { accept?: string; body?: unknown },
+): Promise<unknown> {
+	return (client as unknown as TestableClient).request(method, path, options);
+}
+
+const PAT = 'ghp_supersecrettoken123';
+const OWNER = 'testowner';
+const REPO = 'testrepo';
+const VERSION = '0.0.1';
+
+function makeResponse(
+	status: number,
+	body: unknown = {},
+	headers: Record<string, string> = {},
+): RequestUrlResponse {
+	const text = typeof body === 'string' ? body : JSON.stringify(body);
+	return {
+		status,
+		headers: { 'content-type': 'application/json', ...headers },
+		text,
+		json: typeof body === 'string' ? body : body,
+		arrayBuffer: new ArrayBuffer(0),
+	};
+}
+
+function makeClient(mockSleep?: Mock): { client: GitHubClient; sleep: Mock } {
+	const sleep = mockSleep ?? vi.fn().mockResolvedValue(undefined);
+	const client = new GitHubClient(
+		() => PAT,
+		() => OWNER,
+		() => REPO,
+		VERSION,
+		null,
+		sleep,
+	);
+	return { client, sleep };
+}
+
+describe('GitHubClient', () => {
+	beforeEach(() => {
+		mockRequestUrl.mockReset();
+	});
+
+	describe('headers', () => {
+		test('injects Authorization, Accept, X-GitHub-Api-Version, and User-Agent on every request', async () => {
+			mockRequestUrl.mockResolvedValue(makeResponse(200, { ref: 'refs/heads/main' }));
+			const { client } = makeClient();
+
+			await call(client, 'GET', '/repos/testowner/testrepo/branches/main');
+
+			const param = mockRequestUrl.mock.calls[0][0] as { headers: Record<string, string> };
+			expect(param.headers['Authorization']).toBe(`Bearer ${PAT}`);
+			expect(param.headers['Accept']).toBe('application/vnd.github+json');
+			expect(param.headers['X-GitHub-Api-Version']).toBe('2022-11-28');
+			expect(param.headers['User-Agent']).toBe('obsidian-jackdaw/0.0.1');
+		});
+
+		test('overrides Accept header when accept option is provided', async () => {
+			mockRequestUrl.mockResolvedValue(makeResponse(200, 'raw content'));
+			const { client } = makeClient();
+
+			await call(client, 'GET', '/repos/testowner/testrepo/git/blobs/abc123', {
+				accept: 'application/vnd.github.raw',
+			});
+
+			const param = mockRequestUrl.mock.calls[0][0] as { headers: Record<string, string> };
+			expect(param.headers['Accept']).toBe('application/vnd.github.raw');
+		});
+
+		test('reads PAT fresh on each retry so settings changes take effect', async () => {
+			let callCount = 0;
+			const getPatSpy = vi.fn(() => {
+				callCount++;
+				return `ghp_token_${callCount}`;
+			});
+			const sleep = vi.fn().mockResolvedValue(undefined);
+			const client = new GitHubClient(() => getPatSpy(), () => OWNER, () => REPO, VERSION, null, sleep);
+
+			// Return 429 twice then succeed
+			mockRequestUrl
+				.mockResolvedValueOnce(makeResponse(429, {}, { 'retry-after': '1' }))
+				.mockResolvedValueOnce(makeResponse(200, {}));
+
+			await call(client, 'GET', '/test');
+
+			const firstCall = mockRequestUrl.mock.calls[0][0] as { headers: Record<string, string> };
+			const secondCall = mockRequestUrl.mock.calls[1][0] as { headers: Record<string, string> };
+			expect(firstCall.headers['Authorization']).not.toBe(secondCall.headers['Authorization']);
+		});
+	});
+
+	describe('error handling', () => {
+		test('401 raises GHAuthError and never retries', async () => {
+			mockRequestUrl.mockResolvedValue(makeResponse(401, { message: 'Bad credentials' }));
+			const { client } = makeClient();
+
+			await expect(call(client, 'GET', '/test')).rejects.toThrow(GHAuthError);
+			expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+		});
+
+		test('404 raises GHNotFoundError and never retries', async () => {
+			mockRequestUrl.mockResolvedValue(makeResponse(404, { message: 'Not Found' }));
+			const { client } = makeClient();
+
+			await expect(call(client, 'GET', '/repos/testowner/testrepo/git/refs/heads/missing')).rejects.toThrow(GHNotFoundError);
+			expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+		});
+
+		test('422 raises GHFastForwardError and never retries', async () => {
+			mockRequestUrl.mockResolvedValue(makeResponse(422, { message: 'Update is not a fast forward' }));
+			const { client } = makeClient();
+
+			await expect(call(client, 'PATCH', '/repos/testowner/testrepo/git/refs/heads/main')).rejects.toThrow(GHFastForwardError);
+			expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+		});
+
+		test('429 with Retry-After: 30 retries with backoff up to 3 times then raises GHRateLimitError', async () => {
+			mockRequestUrl.mockResolvedValue(makeResponse(429, { message: 'rate limit' }, { 'retry-after': '30' }));
+			const { client, sleep } = makeClient();
+
+			await expect(call(client, 'GET', '/test')).rejects.toThrow(GHRateLimitError);
+			expect(mockRequestUrl).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+			expect(sleep).toHaveBeenCalledTimes(3);
+		});
+
+		test('403 with retry-after header is treated as secondary rate limit', async () => {
+			mockRequestUrl.mockResolvedValue(makeResponse(403, { message: 'secondary rate limit' }, { 'retry-after': '60' }));
+			const { client } = makeClient();
+
+			await expect(call(client, 'GET', '/test')).rejects.toThrow(GHRateLimitError);
+			expect(mockRequestUrl).toHaveBeenCalledTimes(4);
+		});
+
+		test('403 without retry-after header does not trigger rate-limit retry', async () => {
+			mockRequestUrl.mockResolvedValue(makeResponse(403, { message: 'forbidden' }));
+			const { client } = makeClient();
+
+			// Falls through to GHServerError (unexpected 4xx that isn't explicitly handled)
+			await expect(call(client, 'GET', '/test')).rejects.toThrow(GHServerError);
+			expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+		});
+
+		test('500 retries up to 3 times then raises GHServerError', async () => {
+			mockRequestUrl.mockResolvedValue(makeResponse(500, { message: 'Internal Server Error' }));
+			const { client, sleep } = makeClient();
+
+			await expect(call(client, 'GET', '/test')).rejects.toThrow(GHServerError);
+			expect(mockRequestUrl).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+			expect(sleep).toHaveBeenCalledTimes(3);
+		});
+
+		test('500 succeeds on second attempt without raising', async () => {
+			const { client } = makeClient();
+			mockRequestUrl
+				.mockResolvedValueOnce(makeResponse(500, {}))
+				.mockResolvedValueOnce(makeResponse(200, { ok: true }));
+
+			const result = await call(client, 'GET', '/test');
+			expect(result).toEqual({ ok: true });
+			expect(mockRequestUrl).toHaveBeenCalledTimes(2);
+		});
+
+		test('network error retries once then raises GHNetworkError', async () => {
+			const { client } = makeClient();
+			mockRequestUrl.mockRejectedValue(new Error('ECONNREFUSED'));
+
+			await expect(call(client, 'GET', '/test')).rejects.toThrow(GHNetworkError);
+			expect(mockRequestUrl).toHaveBeenCalledTimes(2);
+		});
+
+		test('network error recovers on second attempt', async () => {
+			const { client } = makeClient();
+			mockRequestUrl
+				.mockRejectedValueOnce(new Error('network failure'))
+				.mockResolvedValueOnce(makeResponse(200, { data: 'ok' }));
+
+			const result = await call(client, 'GET', '/test');
+			expect(result).toEqual({ data: 'ok' });
+			expect(mockRequestUrl).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe('PAT scrubbing', () => {
+		test('PAT does not appear in GHAuthError message when echoed in 401 body', async () => {
+			const body = `{"message":"Bad credentials","token":"${PAT}","hint":"use ${PAT}"}`;
+			mockRequestUrl.mockResolvedValue({
+				status: 401,
+				headers: {},
+				text: body,
+				json: body,
+				arrayBuffer: new ArrayBuffer(0),
+			});
+			const { client } = makeClient();
+
+			const err = await call(client, 'GET', '/test').catch((e: unknown) => e);
+			expect(err).toBeInstanceOf(GHAuthError);
+			expect((err as GHAuthError).message).not.toContain(PAT);
+			expect((err as GHAuthError).message).toContain('[REDACTED]');
+		});
+	});
+
+	describe('rate limit headers', () => {
+		test('emits gh.ratelimit.warn when X-RateLimit-Remaining is below 100', async () => {
+			mockRequestUrl.mockResolvedValue(
+				makeResponse(200, { ok: true }, { 'x-ratelimit-remaining': '42', 'x-ratelimit-reset': '9999999999' }),
+			);
+			const warns: { event: string; fields?: Record<string, unknown> }[] = [];
+			const logger = { warn: vi.fn(async (event: string, fields?: Record<string, unknown>) => { warns.push({ event, fields }); }) };
+			const sleep = vi.fn().mockResolvedValue(undefined);
+			const client = new GitHubClient(() => PAT, () => OWNER, () => REPO, VERSION, logger, sleep);
+
+			await call(client, 'GET', '/test');
+
+			expect(warns.some((w) => w.event === 'gh.ratelimit.warn')).toBe(true);
+			const warn = warns.find((w) => w.event === 'gh.ratelimit.warn');
+			expect(warn?.fields?.remaining).toBe(42);
+		});
+
+		test('raises GHRateLimitError immediately when X-RateLimit-Remaining is 0', async () => {
+			mockRequestUrl.mockResolvedValue(
+				makeResponse(200, { ok: true }, { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': '2000000000' }),
+			);
+			const { client } = makeClient();
+
+			await expect(call(client, 'GET', '/test')).rejects.toThrow(GHRateLimitError);
+			expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('GHRateLimitError retryAfterMs', () => {
+		test('retryAfterMs reflects Retry-After header in seconds converted to ms', async () => {
+			mockRequestUrl.mockResolvedValue(makeResponse(429, {}, { 'retry-after': '30' }));
+			const { client } = makeClient();
+
+			const err = await call(client, 'GET', '/test').catch((e: unknown) => e);
+			expect(err).toBeInstanceOf(GHRateLimitError);
+			expect((err as GHRateLimitError).retryAfterMs).toBe(30_000);
+		});
+	});
+});
+
+describe('encodeBase64Chunked', () => {
+	test('produces same output as btoa for small inputs', () => {
+		const inputs = ['hello world', '', 'abc', 'The quick brown fox'];
+		for (const s of inputs) {
+			const buf = new TextEncoder().encode(s).buffer;
+			expect(encodeBase64Chunked(buf)).toBe(btoa(s));
+		}
+	});
+
+	test('handles a buffer larger than 1 MB without throwing', () => {
+		const buf = new Uint8Array(1.1 * 1024 * 1024).fill(65).buffer; // 1.1 MB of 'A'
+		expect(() => encodeBase64Chunked(buf)).not.toThrow();
+		// All 'A' bytes → base64 should consist only of 'Q' and '='
+		const result = encodeBase64Chunked(buf);
+		expect(result.length).toBeGreaterThan(0);
+		expect(/^[A-Za-z0-9+/]+=*$/.test(result)).toBe(true);
+	});
+
+	test('empty buffer produces empty base64 string', () => {
+		expect(encodeBase64Chunked(new ArrayBuffer(0))).toBe('');
+	});
+});

--- a/src/github-client.test.ts
+++ b/src/github-client.test.ts
@@ -53,7 +53,7 @@ function makeResponse(
 		status,
 		headers: { 'content-type': 'application/json', ...headers },
 		text,
-		json: typeof body === 'string' ? body : body,
+		json: body,
 		arrayBuffer: new ArrayBuffer(0),
 	};
 }
@@ -102,14 +102,27 @@ describe('GitHubClient', () => {
 			expect(param.headers['Accept']).toBe('application/vnd.github.raw');
 		});
 
-		test('reads PAT fresh on each retry so settings changes take effect', async () => {
-			let callCount = 0;
-			const getPatSpy = vi.fn(() => {
-				callCount++;
-				return `ghp_token_${callCount}`;
+		test('sets Content-Type: application/json and serializes body when body option is provided', async () => {
+			mockRequestUrl.mockResolvedValue(makeResponse(200, {}));
+			const { client } = makeClient();
+
+			await call(client, 'POST', '/repos/testowner/testrepo/git/blobs', {
+				body: { content: 'aGVsbG8=', encoding: 'base64' },
 			});
+
+			const param = mockRequestUrl.mock.calls[0][0] as {
+				headers: Record<string, string>;
+				body: string;
+			};
+			expect(param.headers['Content-Type']).toBe('application/json');
+			expect(JSON.parse(param.body)).toEqual({ content: 'aGVsbG8=', encoding: 'base64' });
+		});
+
+		test('reads PAT fresh on each retry so settings changes take effect', async () => {
+			let n = 0;
+			const getPat = vi.fn(() => `ghp_token_${++n}`);
 			const sleep = vi.fn().mockResolvedValue(undefined);
-			const client = new GitHubClient(() => getPatSpy(), () => OWNER, () => REPO, VERSION, null, sleep);
+			const client = new GitHubClient(getPat, () => OWNER, () => REPO, VERSION, null, sleep);
 
 			// Return 429 twice then succeed
 			mockRequestUrl

--- a/src/github-client.ts
+++ b/src/github-client.ts
@@ -1,0 +1,211 @@
+import { requestUrl } from 'obsidian';
+import { PLUGIN_ID } from './constants';
+
+const GITHUB_API_BASE = 'https://api.github.com';
+const API_VERSION = '2022-11-28';
+const MAX_RETRIES = 3;
+const NETWORK_RETRY_MS = 2000;
+
+export class GHAuthError extends Error {
+	override readonly name = 'GHAuthError';
+}
+
+export class GHNotFoundError extends Error {
+	override readonly name = 'GHNotFoundError';
+}
+
+export class GHRateLimitError extends Error {
+	override readonly name = 'GHRateLimitError';
+	readonly retryAfterMs: number;
+	constructor(message: string, retryAfterMs: number) {
+		super(message);
+		this.retryAfterMs = retryAfterMs;
+	}
+}
+
+export class GHFastForwardError extends Error {
+	override readonly name = 'GHFastForwardError';
+}
+
+export class GHNetworkError extends Error {
+	override readonly name = 'GHNetworkError';
+}
+
+export class GHServerError extends Error {
+	override readonly name = 'GHServerError';
+	readonly status: number;
+	constructor(message: string, status: number) {
+		super(message);
+		this.status = status;
+	}
+}
+
+export interface GHLogger {
+	warn(event: string, fields?: Record<string, unknown>): Promise<void>;
+}
+
+interface RequestOptions {
+	body?: unknown;
+	accept?: string;
+}
+
+// Encodes an ArrayBuffer to base64 using chunked processing to avoid the
+// spread-argument stack overflow that btoa(String.fromCharCode(...largeArray)) hits for >~65K bytes.
+export function encodeBase64Chunked(buffer: ArrayBuffer): string {
+	const bytes = new Uint8Array(buffer);
+	const CHUNK = 0x8000; // 32 KB chunks
+	const parts: string[] = [];
+	for (let i = 0; i < bytes.length; i += CHUNK) {
+		parts.push(String.fromCharCode(...bytes.subarray(i, i + CHUNK)));
+	}
+	return btoa(parts.join(''));
+}
+
+export class GitHubClient {
+	private readonly getPat: () => string;
+	private readonly getOwner: () => string;
+	private readonly getRepo: () => string;
+	private readonly version: string;
+	private readonly logger: GHLogger | null;
+	private readonly doSleep: (ms: number) => Promise<void>;
+
+	constructor(
+		getPat: () => string,
+		getOwner: () => string,
+		getRepo: () => string,
+		version: string,
+		logger: GHLogger | null = null,
+		sleep?: (ms: number) => Promise<void>,
+	) {
+		this.getPat = getPat;
+		this.getOwner = getOwner;
+		this.getRepo = getRepo;
+		this.version = version;
+		this.logger = logger;
+		this.doSleep = sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+	}
+
+	private async request(
+		method: string,
+		path: string,
+		options: RequestOptions = {},
+	): Promise<unknown> {
+		const url = `${GITHUB_API_BASE}${path}`;
+		const bodyStr = options.body !== undefined ? JSON.stringify(options.body) : undefined;
+
+		let rateRetries = 0;
+		let serverRetries = 0;
+		let networkRetried = false;
+
+		for (;;) {
+			const pat = this.getPat();
+			const headers: Record<string, string> = {
+				Authorization: `Bearer ${pat}`,
+				Accept: options.accept ?? 'application/vnd.github+json',
+				'X-GitHub-Api-Version': API_VERSION,
+				'User-Agent': `obsidian-${PLUGIN_ID}/${this.version}`,
+			};
+			if (bodyStr !== undefined) {
+				headers['Content-Type'] = 'application/json';
+			}
+
+			let response;
+			try {
+				response = await requestUrl({
+					url,
+					method,
+					headers,
+					body: bodyStr,
+					throw: false,
+				});
+			} catch (err) {
+				if (networkRetried) {
+					throw new GHNetworkError(
+						`Network error: ${err instanceof Error ? err.message : String(err)}`,
+					);
+				}
+				networkRetried = true;
+				await this.doSleep(NETWORK_RETRY_MS);
+				continue;
+			}
+
+			const remaining = parseInt(response.headers['x-ratelimit-remaining'] ?? '-1', 10);
+			const resetUnix = parseInt(response.headers['x-ratelimit-reset'] ?? '0', 10);
+
+			if (remaining === 0) {
+				const resetAt = new Date(resetUnix * 1000).toISOString();
+				throw new GHRateLimitError(
+					`GitHub rate limit exhausted. Resets at ${resetAt}.`,
+					Math.max(0, resetUnix * 1000 - Date.now()),
+				);
+			}
+			if (remaining > 0 && remaining < 100) {
+				await this.logger?.warn('gh.ratelimit.warn', { remaining, resetAt: resetUnix });
+			}
+
+			const { status } = response;
+
+			if (status >= 200 && status < 300) {
+				try {
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+					return response.json;
+				} catch {
+					return response.text;
+				}
+			}
+
+			const safeBody = this.scrubPat(response.text ?? '').slice(0, 200);
+
+			if (status === 401) {
+				throw new GHAuthError(`Authentication failed. Check your token. (${safeBody})`);
+			}
+
+			if (status === 404) {
+				throw new GHNotFoundError(
+					`Not found: ${path}. The resource may not exist or your token may lack permissions.`,
+				);
+			}
+
+			if (status === 429 || (status === 403 && 'retry-after' in response.headers)) {
+				const retryAfterSec = parseInt(response.headers['retry-after'] ?? '60', 10);
+				const retryAfterMs = Number.isNaN(retryAfterSec) ? 60_000 : retryAfterSec * 1000;
+				if (rateRetries >= MAX_RETRIES) {
+					throw new GHRateLimitError(
+						`Rate limit exceeded after ${MAX_RETRIES} retries. Retry after ${retryAfterMs}ms.`,
+						retryAfterMs,
+					);
+				}
+				await this.doSleep(this.backoff(rateRetries, retryAfterMs));
+				rateRetries++;
+				continue;
+			}
+
+			if (status === 422) {
+				throw new GHFastForwardError(
+					`Ref update rejected (fast-forward required). Another client may have pushed to the branch.`,
+				);
+			}
+
+			if (status >= 500) {
+				if (serverRetries >= MAX_RETRIES) {
+					throw new GHServerError(`Server error ${status}: ${safeBody}`, status);
+				}
+				await this.doSleep(this.backoff(serverRetries, 1000));
+				serverRetries++;
+				continue;
+			}
+
+			throw new GHServerError(`Unexpected status ${status}: ${safeBody}`, status);
+		}
+	}
+
+	private scrubPat(text: string): string {
+		const pat = this.getPat();
+		return pat ? text.split(pat).join('[REDACTED]') : text;
+	}
+
+	private backoff(retryCount: number, baseMs: number): number {
+		const expo = Math.min(baseMs * 2 ** retryCount, 60_000);
+		return expo + Math.random() * 0.1 * expo;
+	}
+}

--- a/src/github-client.ts
+++ b/src/github-client.ts
@@ -132,13 +132,6 @@ export class GitHubClient {
 			const remaining = parseInt(response.headers['x-ratelimit-remaining'] ?? '-1', 10);
 			const resetUnix = parseInt(response.headers['x-ratelimit-reset'] ?? '0', 10);
 
-			if (remaining === 0) {
-				const resetAt = new Date(resetUnix * 1000).toISOString();
-				throw new GHRateLimitError(
-					`GitHub rate limit exhausted. Resets at ${resetAt}.`,
-					Math.max(0, resetUnix * 1000 - Date.now()),
-				);
-			}
 			if (remaining > 0 && remaining < 100) {
 				await this.logger?.warn('gh.ratelimit.warn', { remaining, resetAt: resetUnix });
 			}
@@ -146,9 +139,15 @@ export class GitHubClient {
 			const { status } = response;
 
 			if (status >= 200 && status < 300) {
+				if (remaining === 0) {
+					const resetAt = new Date(resetUnix * 1000).toISOString();
+					throw new GHRateLimitError(
+						`GitHub rate limit exhausted. Resets at ${resetAt}.`,
+						Math.max(0, resetUnix * 1000 - Date.now()),
+					);
+				}
 				try {
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-					return response.json;
+					return response.json as unknown;
 				} catch {
 					return response.text;
 				}


### PR DESCRIPTION
Implements the HTTP transport layer for the GitHub REST API:
- GitHubClient class with private request() method using requestUrl
- PAT/owner/repo read via getter callbacks on every call (§6.2)
- Default headers: Authorization, Accept, X-GitHub-Api-Version, User-Agent (§6.3)
- Typed errors: GHAuthError, GHNotFoundError, GHRateLimitError,
  GHFastForwardError, GHNetworkError, GHServerError
- Retry policy: rate-limit (Retry-After + exponential backoff, max 3),
  network (single retry after 2s), no retry on 401/422 (§6.4)
- X-RateLimit-Remaining: warn below 100, raise immediately at 0
- PAT scrubbing from all error messages
- Chunked base64 encoder (encodeBase64Chunked) for ArrayBuffers > 1 MB
- Full test coverage for all acceptance criteria

Closes #23

https://claude.ai/code/session_01EEBNex8e9wGyWqmbNJuede