### PR TITLE
Implement .git/ hard-exclusion and vault-root .gitignore support in file scanner

### DIFF
--- a/src/file-scanner.test.ts
+++ b/src/file-scanner.test.ts
@@ -74,6 +74,11 @@ describe('matchesGlob', () => {
 		expect(matchesGlob('node_modules/', 'other/index.js')).toBe(false);
 	});
 
+	test('* does not match partial names (guards against missing escape)', () => {
+		expect(matchesGlob('*.tmp', 'tmpfile')).toBe(false);
+		expect(matchesGlob('*.tmp', 'notes/tmpfile')).toBe(false);
+	});
+
 	test('pattern with slash matches full vault-relative path', () => {
 		expect(
 			matchesGlob(

--- a/src/file-scanner.test.ts
+++ b/src/file-scanner.test.ts
@@ -1,0 +1,292 @@
+import { describe, test, expect } from 'vitest';
+import { parseGitignorePatterns, matchesGlob, isExcluded, FileScanner } from './file-scanner';
+import type { VaultAdapter } from './sync-engine-types';
+
+interface AdapterSpec {
+	exists?: Record<string, boolean>;
+	listFiles?: string[];
+	listDirectory?: Record<string, { files: string[]; dirs: string[] }>;
+	readText?: Record<string, string>;
+}
+
+function makeAdapter(spec: AdapterSpec = {}): VaultAdapter {
+	return {
+		exists: (path: string) => Promise.resolve(spec.exists?.[path] ?? false),
+		listFiles: () => Promise.resolve(spec.listFiles ?? []),
+		listDirectory: (path: string) =>
+			Promise.resolve(spec.listDirectory?.[path] ?? { files: [], dirs: [] }),
+		readText: (path: string) => Promise.resolve(spec.readText?.[path] ?? ''),
+		readBinary: () => Promise.resolve(new ArrayBuffer(0)),
+		writeText: () => Promise.resolve(),
+		writeBinary: () => Promise.resolve(),
+		delete: () => Promise.resolve(),
+	};
+}
+
+describe('parseGitignorePatterns', () => {
+	test('returns non-blank, non-comment, non-negation lines', () => {
+		const content = ['*.log', 'node_modules/', '.DS_Store'].join('\n');
+		expect(parseGitignorePatterns(content)).toEqual(['*.log', 'node_modules/', '.DS_Store']);
+	});
+
+	test('skips blank lines', () => {
+		expect(parseGitignorePatterns('\n\n*.log\n\n')).toEqual(['*.log']);
+	});
+
+	test('skips comment lines', () => {
+		expect(parseGitignorePatterns('# comment\n*.log\n# another')).toEqual(['*.log']);
+	});
+
+	test('skips negation lines without error', () => {
+		expect(parseGitignorePatterns('*.log\n!important.log\n*.tmp')).toEqual(['*.log', '*.tmp']);
+	});
+
+	test('trims whitespace from lines', () => {
+		expect(parseGitignorePatterns('  *.log  ')).toEqual(['*.log']);
+	});
+
+	test('empty content returns empty array', () => {
+		expect(parseGitignorePatterns('')).toEqual([]);
+	});
+});
+
+describe('matchesGlob', () => {
+	test('* matches within a single path segment', () => {
+		expect(matchesGlob('*.tmp', 'file.tmp')).toBe(true);
+		expect(matchesGlob('*.tmp', 'file.txt')).toBe(false);
+	});
+
+	test('pattern without slash matches against basename at any depth', () => {
+		expect(matchesGlob('.DS_Store', '.DS_Store')).toBe(true);
+		expect(matchesGlob('.DS_Store', 'notes/.DS_Store')).toBe(true);
+		expect(matchesGlob('.DS_Store', 'notes/file.md')).toBe(false);
+		expect(matchesGlob('*.tmp', 'deep/nested/file.tmp')).toBe(true);
+	});
+
+	test('** matches across path segments', () => {
+		expect(matchesGlob('.trash/**', '.trash/file.md')).toBe(true);
+		expect(matchesGlob('.trash/**', '.trash/subdir/file.md')).toBe(true);
+		expect(matchesGlob('.trash/**', 'other/file.md')).toBe(false);
+	});
+
+	test('trailing slash is treated as directory prefix match', () => {
+		expect(matchesGlob('node_modules/', 'node_modules/lodash/index.js')).toBe(true);
+		expect(matchesGlob('node_modules/', 'other/index.js')).toBe(false);
+	});
+
+	test('pattern with slash matches full vault-relative path', () => {
+		expect(
+			matchesGlob(
+				'.obsidian/plugins/jackdaw/data.json',
+				'.obsidian/plugins/jackdaw/data.json',
+			),
+		).toBe(true);
+		expect(matchesGlob('.obsidian/plugins/jackdaw/data.json', 'other/data.json')).toBe(false);
+	});
+});
+
+describe('isExcluded', () => {
+	test('returns true when any pattern matches', () => {
+		expect(isExcluded('file.tmp', ['*.tmp', '*.swp'])).toBe(true);
+		expect(isExcluded('file.swp', ['*.tmp', '*.swp'])).toBe(true);
+	});
+
+	test('returns false when no pattern matches', () => {
+		expect(isExcluded('notes.md', ['*.tmp', '*.swp'])).toBe(false);
+	});
+
+	test('returns false for empty pattern list', () => {
+		expect(isExcluded('file.tmp', [])).toBe(false);
+	});
+});
+
+describe('FileScanner', () => {
+	test('no .gitignore: returns all vault files not excluded by self or user patterns', async () => {
+		const adapter = makeAdapter({
+			exists: { '.gitignore': false },
+			listFiles: ['notes/hello.md', 'notes/world.md', 'image.png'],
+		});
+		const scanner = new FileScanner(adapter, {
+			includeObsidianConfig: false,
+			userExcludePatterns: [],
+		});
+		expect(await scanner.scan()).toEqual(['notes/hello.md', 'notes/world.md', 'image.png']);
+	});
+
+	test('.gitignore patterns exclude matching files', async () => {
+		const adapter = makeAdapter({
+			exists: { '.gitignore': true },
+			readText: { '.gitignore': '*.log\nbuild/' },
+			listFiles: ['notes/hello.md', 'error.log', 'build/output.js'],
+		});
+		const scanner = new FileScanner(adapter, {
+			includeObsidianConfig: false,
+			userExcludePatterns: [],
+		});
+		const results = await scanner.scan();
+		expect(results).toContain('notes/hello.md');
+		expect(results).not.toContain('error.log');
+		expect(results).not.toContain('build/output.js');
+	});
+
+	test('.gitignore comment lines, blank lines, and negation lines are safely ignored', async () => {
+		const adapter = makeAdapter({
+			exists: { '.gitignore': true },
+			readText: {
+				'.gitignore': [
+					'# Build output',
+					'',
+					'*.log',
+					'!important.log',
+					'',
+					'*.tmp',
+				].join('\n'),
+			},
+			listFiles: ['build.log', 'important.log', 'temp.tmp', 'notes.md'],
+		});
+		const scanner = new FileScanner(adapter, {
+			includeObsidianConfig: false,
+			userExcludePatterns: [],
+		});
+		const results = await scanner.scan();
+		// *.log pattern applies; negation line is ignored for v1
+		expect(results).not.toContain('build.log');
+		expect(results).not.toContain('important.log');
+		expect(results).not.toContain('temp.tmp');
+		expect(results).toContain('notes.md');
+	});
+
+	test('.gitignore and .gitattributes are not excluded', async () => {
+		const adapter = makeAdapter({
+			exists: { '.gitignore': true },
+			readText: { '.gitignore': '*.log' },
+			listFiles: ['.gitignore', '.gitattributes', 'notes.md', 'debug.log'],
+		});
+		const scanner = new FileScanner(adapter, {
+			includeObsidianConfig: false,
+			userExcludePatterns: [],
+		});
+		const results = await scanner.scan();
+		expect(results).toContain('.gitignore');
+		expect(results).toContain('.gitattributes');
+		expect(results).not.toContain('debug.log');
+	});
+
+	test('user exclude patterns are applied', async () => {
+		const adapter = makeAdapter({
+			exists: { '.gitignore': false },
+			listFiles: ['notes.md', 'temp.swp', '.DS_Store', 'data.tmp'],
+		});
+		const scanner = new FileScanner(adapter, {
+			includeObsidianConfig: false,
+			userExcludePatterns: ['*.swp', '.DS_Store', '*.tmp'],
+		});
+		const results = await scanner.scan();
+		expect(results).toContain('notes.md');
+		expect(results).not.toContain('temp.swp');
+		expect(results).not.toContain('.DS_Store');
+		expect(results).not.toContain('data.tmp');
+	});
+
+	test('self-excluded plugin paths are never included', async () => {
+		const pluginFiles = [
+			'.obsidian/plugins/jackdaw/data.json',
+			'.obsidian/plugins/jackdaw/sync-state.json',
+			'.obsidian/plugins/jackdaw/sync-state.json.tmp',
+			'.obsidian/plugins/jackdaw/sync.log',
+			'.obsidian/plugins/jackdaw/sync.log.1',
+		];
+		const adapter = makeAdapter({
+			exists: { '.gitignore': false },
+			listFiles: [...pluginFiles, 'notes.md'],
+		});
+		const scanner = new FileScanner(adapter, {
+			includeObsidianConfig: false,
+			userExcludePatterns: [],
+		});
+		const results = await scanner.scan();
+		for (const p of pluginFiles) {
+			expect(results).not.toContain(p);
+		}
+		expect(results).toContain('notes.md');
+	});
+
+	test('.git directory is never descended into during adapter walk', async () => {
+		const adapter = makeAdapter({
+			exists: { '.gitignore': false },
+			listFiles: [],
+			listDirectory: {
+				'.obsidian': { files: ['app.json'], dirs: ['.git', 'plugins'] },
+				// If .git were descended into, COMMIT_EDITMSG would be found
+				'.obsidian/.git': { files: ['COMMIT_EDITMSG'], dirs: [] },
+				'.obsidian/plugins': { files: ['my-plugin.js'], dirs: [] },
+			},
+		});
+		const scanner = new FileScanner(adapter, {
+			includeObsidianConfig: true,
+			userExcludePatterns: [],
+		});
+		const results = await scanner.scan();
+		expect(results).not.toContain('.obsidian/.git/COMMIT_EDITMSG');
+		expect(results).toContain('.obsidian/app.json');
+		expect(results).toContain('.obsidian/plugins/my-plugin.js');
+	});
+
+	test('obsidian config walk is skipped when includeObsidianConfig is false', async () => {
+		const adapter = makeAdapter({
+			exists: { '.gitignore': false },
+			listFiles: ['notes.md'],
+			listDirectory: {
+				'.obsidian': { files: ['app.json'], dirs: [] },
+			},
+		});
+		const scanner = new FileScanner(adapter, {
+			includeObsidianConfig: false,
+			userExcludePatterns: [],
+		});
+		const results = await scanner.scan();
+		expect(results).toEqual(['notes.md']);
+	});
+
+	test('obsidian config walk includes files when includeObsidianConfig is true', async () => {
+		const adapter = makeAdapter({
+			exists: { '.gitignore': false },
+			listFiles: ['notes.md'],
+			listDirectory: {
+				'.obsidian': { files: ['app.json'], dirs: ['snippets'] },
+				'.obsidian/snippets': { files: ['custom.css'], dirs: [] },
+			},
+		});
+		const scanner = new FileScanner(adapter, {
+			includeObsidianConfig: true,
+			userExcludePatterns: [],
+		});
+		const results = await scanner.scan();
+		expect(results).toContain('notes.md');
+		expect(results).toContain('.obsidian/app.json');
+		expect(results).toContain('.obsidian/snippets/custom.css');
+	});
+
+	test('self-excluded paths are filtered from obsidian walk too', async () => {
+		const adapter = makeAdapter({
+			exists: { '.gitignore': false },
+			listFiles: [],
+			listDirectory: {
+				'.obsidian': { files: [], dirs: ['plugins'] },
+				'.obsidian/plugins': { files: [], dirs: ['jackdaw'] },
+				'.obsidian/plugins/jackdaw': {
+					files: ['data.json', 'sync-state.json', 'main.js'],
+					dirs: [],
+				},
+			},
+		});
+		const scanner = new FileScanner(adapter, {
+			includeObsidianConfig: true,
+			userExcludePatterns: [],
+		});
+		const results = await scanner.scan();
+		expect(results).not.toContain('.obsidian/plugins/jackdaw/data.json');
+		expect(results).not.toContain('.obsidian/plugins/jackdaw/sync-state.json');
+		expect(results).toContain('.obsidian/plugins/jackdaw/main.js');
+	});
+});

--- a/src/file-scanner.ts
+++ b/src/file-scanner.ts
@@ -8,36 +8,52 @@ export function parseGitignorePatterns(content: string): string[] {
 		.filter(line => line.length > 0 && !line.startsWith('#') && !line.startsWith('!'));
 }
 
-export function matchesGlob(pattern: string, path: string): boolean {
+interface CompiledGlob {
+	regex: RegExp;
+	hasSlash: boolean;
+}
+
+const globCache = new Map<string, CompiledGlob>();
+
+function compileGlob(pattern: string): CompiledGlob {
 	// Trailing slash means "match this directory and everything inside it"
 	const normalized = pattern.endsWith('/') ? pattern + '**' : pattern;
 	// Patterns with no slash match against the basename only
 	const hasSlash = normalized.includes('/');
-	const subject = hasSlash ? path : (path.split('/').pop() ?? path);
 
-	let regex = '';
+	let regexStr = '';
 	for (let i = 0; i < normalized.length; i++) {
 		const ch = normalized[i];
 		if (ch === '*' && i + 1 < normalized.length && normalized[i + 1] === '*') {
 			if (i + 2 < normalized.length && normalized[i + 2] === '/') {
 				// **/ matches zero or more directory segments
-				regex += '(?:.+/)?';
+				regexStr += '(?:.+/)?';
 				i += 2;
 			} else {
 				// ** matches anything including path separators
-				regex += '.*';
+				regexStr += '.*';
 				i++;
 			}
 		} else if (ch === '*') {
-			regex += '[^/]*';
+			regexStr += '[^/]*';
 		} else if (ch === '?') {
-			regex += '[^/]';
+			regexStr += '[^/]';
 		} else {
-			regex += ch.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+			regexStr += ch.replace(/[.+^${}()|[\]\\]/g, '\\$&');
 		}
 	}
 
-	return new RegExp('^' + regex + '$').test(subject);
+	return { regex: new RegExp('^' + regexStr + '$'), hasSlash };
+}
+
+export function matchesGlob(pattern: string, path: string): boolean {
+	let compiled = globCache.get(pattern);
+	if (!compiled) {
+		compiled = compileGlob(pattern);
+		globCache.set(pattern, compiled);
+	}
+	const subject = compiled.hasSlash ? path : (path.split('/').pop() ?? path);
+	return compiled.regex.test(subject);
 }
 
 export function isExcluded(path: string, patterns: readonly string[]): boolean {
@@ -65,11 +81,12 @@ export class FileScanner {
 
 		exclusions.push(...this.config.userExcludePatterns);
 
-		const candidates: string[] = [];
+		// Use a Set to prevent duplicates if a path appears in both listFiles() and the adapter walk
+		const candidates = new Set<string>();
 
 		for (const path of await this.adapter.listFiles()) {
 			if (!isExcluded(path, exclusions)) {
-				candidates.push(path);
+				candidates.add(path);
 			}
 		}
 
@@ -77,12 +94,12 @@ export class FileScanner {
 			await this.walkDirectory('.obsidian', candidates, exclusions);
 		}
 
-		return candidates;
+		return [...candidates];
 	}
 
 	private async walkDirectory(
 		dir: string,
-		results: string[],
+		results: Set<string>,
 		exclusions: string[],
 	): Promise<void> {
 		const { files, dirs } = await this.adapter.listDirectory(dir);
@@ -90,7 +107,7 @@ export class FileScanner {
 		for (const fileName of files) {
 			const path = `${dir}/${fileName}`;
 			if (!isExcluded(path, exclusions)) {
-				results.push(path);
+				results.add(path);
 			}
 		}
 

--- a/src/file-scanner.ts
+++ b/src/file-scanner.ts
@@ -1,0 +1,103 @@
+import { SELF_EXCLUDED_PATHS } from './constants';
+import type { VaultAdapter } from './sync-engine-types';
+
+export function parseGitignorePatterns(content: string): string[] {
+	return content
+		.split('\n')
+		.map(line => line.trim())
+		.filter(line => line.length > 0 && !line.startsWith('#') && !line.startsWith('!'));
+}
+
+export function matchesGlob(pattern: string, path: string): boolean {
+	// Trailing slash means "match this directory and everything inside it"
+	const normalized = pattern.endsWith('/') ? pattern + '**' : pattern;
+	// Patterns with no slash match against the basename only
+	const hasSlash = normalized.includes('/');
+	const subject = hasSlash ? path : (path.split('/').pop() ?? path);
+
+	let regex = '';
+	for (let i = 0; i < normalized.length; i++) {
+		const ch = normalized[i];
+		if (ch === '*' && i + 1 < normalized.length && normalized[i + 1] === '*') {
+			if (i + 2 < normalized.length && normalized[i + 2] === '/') {
+				// **/ matches zero or more directory segments
+				regex += '(?:.+/)?';
+				i += 2;
+			} else {
+				// ** matches anything including path separators
+				regex += '.*';
+				i++;
+			}
+		} else if (ch === '*') {
+			regex += '[^/]*';
+		} else if (ch === '?') {
+			regex += '[^/]';
+		} else {
+			regex += ch.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+		}
+	}
+
+	return new RegExp('^' + regex + '$').test(subject);
+}
+
+export function isExcluded(path: string, patterns: readonly string[]): boolean {
+	return patterns.some(pattern => matchesGlob(pattern, path));
+}
+
+export interface FileScannerConfig {
+	includeObsidianConfig: boolean;
+	userExcludePatterns: string[];
+}
+
+export class FileScanner {
+	constructor(
+		private readonly adapter: VaultAdapter,
+		private readonly config: FileScannerConfig,
+	) {}
+
+	async scan(): Promise<string[]> {
+		const exclusions: string[] = [...SELF_EXCLUDED_PATHS];
+
+		if (await this.adapter.exists('.gitignore')) {
+			const content = await this.adapter.readText('.gitignore');
+			exclusions.push(...parseGitignorePatterns(content));
+		}
+
+		exclusions.push(...this.config.userExcludePatterns);
+
+		const candidates: string[] = [];
+
+		for (const path of await this.adapter.listFiles()) {
+			if (!isExcluded(path, exclusions)) {
+				candidates.push(path);
+			}
+		}
+
+		if (this.config.includeObsidianConfig) {
+			await this.walkDirectory('.obsidian', candidates, exclusions);
+		}
+
+		return candidates;
+	}
+
+	private async walkDirectory(
+		dir: string,
+		results: string[],
+		exclusions: string[],
+	): Promise<void> {
+		const { files, dirs } = await this.adapter.listDirectory(dir);
+
+		for (const fileName of files) {
+			const path = `${dir}/${fileName}`;
+			if (!isExcluded(path, exclusions)) {
+				results.push(path);
+			}
+		}
+
+		for (const dirName of dirs) {
+			// Hard-exclude .git/ at the directory level — never descend into it
+			if (dirName === '.git') continue;
+			await this.walkDirectory(`${dir}/${dirName}`, results, exclusions);
+		}
+	}
+}


### PR DESCRIPTION
Adds FileScanner class with:
- parseGitignorePatterns: reads vault-root .gitignore, skipping blank, comment, and negation lines
- matchesGlob: gitignore-style glob matching (* within segment, ** across segments, trailing / as dir prefix)
- isExcluded: applies a pattern list to a vault-relative path
- FileScanner.scan(): collects candidates from listFiles() + optional .obsidian walk, applying SELF_EXCLUDED_PATHS, .gitignore patterns, and user exclude patterns
- walkDirectory: never descends into any directory named .git (directory-level check, not per-file filter)

Closes #36

https://claude.ai/code/session_01HsEA7aZFfrvWoD7BScreYT