### PR TITLE
Add classifier module for sync conflict resolution

### DIFF
--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -1,0 +1,69 @@
+import type { LocalChange, RemoteChange, LocalChangeType, RemoteChangeType, ClassifyAction, ClassifiedPath } from './sync-engine-types';
+import type { SyncState } from './state-store';
+
+export interface ClassifierLogger {
+	warn(event: string, data?: Record<string, unknown>): void;
+}
+
+export function classify(
+	localChanges: Map<string, LocalChange>,
+	remoteChanges: Map<string, RemoteChange>,
+	_state: SyncState,
+	logger?: ClassifierLogger,
+): ClassifiedPath[] {
+	const allPaths = new Set([...localChanges.keys(), ...remoteChanges.keys()]);
+	const result: ClassifiedPath[] = [];
+
+	for (const path of allPaths) {
+		const localType: LocalChangeType = localChanges.get(path)?.type ?? 'unchanged';
+		const remoteType: RemoteChangeType = remoteChanges.get(path)?.type ?? 'unchanged';
+		const action = resolveAction(localType, remoteType, path, logger);
+		result.push({ path, action, local: localType, remote: remoteType });
+	}
+
+	return result;
+}
+
+function resolveAction(
+	local: LocalChangeType,
+	remote: RemoteChangeType,
+	path: string,
+	logger?: ClassifierLogger,
+): ClassifyAction {
+	if (local === 'unchanged') {
+		// Remote drives: pull anything that changed, no-op if both unchanged
+		if (remote === 'unchanged') return 'no-op';
+		return 'pull';
+	}
+
+	if (local === 'added') {
+		if (remote === 'unchanged') return 'push';
+		// Both added: hash comparison (sha256 vs git blob sha1) deferred to pull phase
+		if (remote === 'added') return 'conflict';
+		// Impossible: path not in state, so remote can't be modified or deleted
+		logger?.warn('classifier:impossible-cell', { path, local, remote });
+		return 'no-op';
+	}
+
+	if (local === 'modified') {
+		if (remote === 'unchanged') return 'push';
+		// Impossible: path in state, so remote can't be newly added
+		if (remote === 'added') {
+			logger?.warn('classifier:impossible-cell', { path, local, remote });
+			return 'no-op';
+		}
+		// Both modified or local modified + remote deleted
+		return 'conflict';
+	}
+
+	// local === 'deleted'
+	if (remote === 'unchanged') return 'push';
+	if (remote === 'deleted') return 'no-op';
+	// Impossible: path in state, so remote can't be newly added
+	if (remote === 'added') {
+		logger?.warn('classifier:impossible-cell', { path, local, remote });
+		return 'no-op';
+	}
+	// remote === 'modified'
+	return 'conflict';
+}

--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -1,6 +1,8 @@
 import type { LocalChange, RemoteChange, LocalChangeType, RemoteChangeType, ClassifyAction, ClassifiedPath } from './sync-engine-types';
 import type { SyncState } from './state-store';
 
+// Intentionally sync — classify() is pure with no I/O. Callers using the async
+// Logger from state-store.ts need to wrap it (e.g. (e, d) => void logger.warn(e, d)).
 export interface ClassifierLogger {
 	warn(event: string, data?: Record<string, unknown>): void;
 }
@@ -8,7 +10,7 @@ export interface ClassifierLogger {
 export function classify(
 	localChanges: Map<string, LocalChange>,
 	remoteChanges: Map<string, RemoteChange>,
-	_state: SyncState,
+	_state: SyncState, // reserved — staleness comparison (§4.4) is deferred to the pull phase
 	logger?: ClassifierLogger,
 ): ClassifiedPath[] {
 	const allPaths = new Set([...localChanges.keys(), ...remoteChanges.keys()]);

--- a/src/sync-engine-types.ts
+++ b/src/sync-engine-types.ts
@@ -18,8 +18,11 @@ export interface RemoteChange {
 	isBinary: boolean;
 }
 
+export type ClassifyAction = 'pull' | 'push' | 'conflict' | 'no-op';
+
 export interface ClassifiedPath {
 	path: string;
+	action: ClassifyAction;
 	local: LocalChangeType;
 	remote: RemoteChangeType;
 }

--- a/tests/classifier.test.ts
+++ b/tests/classifier.test.ts
@@ -20,11 +20,7 @@ function makeRemote(path: string, type: RemoteChange['type'], blobSha = 'blobsha
 }
 
 function makeLogger() {
-	const warns: Array<[string, Record<string, unknown> | undefined]> = [];
-	return {
-		warn: vi.fn((event: string, data?: Record<string, unknown>) => { warns.push([event, data]); }),
-		warns,
-	};
+	return { warn: vi.fn<[string, (Record<string, unknown> | undefined)?], void>() };
 }
 
 const EMPTY = new Map<string, LocalChange>();
@@ -66,17 +62,10 @@ test('(added, added) — conflict (hash comparison deferred to pull phase)', () 
 	expect(result[0]).toMatchObject({ action: 'conflict', local: 'added', remote: 'added' });
 });
 
-describe('(added, added) same-content escape: classifier returns conflict regardless of hash values', () => {
-	test('with matching content hash values — still conflict (deferred)', () => {
-		// sha256 vs git blob sha1 can't be directly compared; classifier always returns conflict
-		const result = classify(makeLocal('a.md', 'added', 'same'), makeRemote('a.md', 'added', 'same'), EMPTY_STATE);
-		expect(result[0]).toMatchObject({ action: 'conflict' });
-	});
-
-	test('with differing hash values — conflict', () => {
-		const result = classify(makeLocal('a.md', 'added', 'hash-a'), makeRemote('a.md', 'added', 'hash-b'), EMPTY_STATE);
-		expect(result[0]).toMatchObject({ action: 'conflict' });
-	});
+test('(added, added) always conflict — sha256 vs git blob sha1 cannot be compared without I/O', () => {
+	// Hash comparison (same-content escape) is deferred to the pull phase; classifier has no I/O
+	const result = classify(makeLocal('a.md', 'added', 'hash-a'), makeRemote('a.md', 'added', 'hash-b'), EMPTY_STATE);
+	expect(result[0]).toMatchObject({ action: 'conflict' });
 });
 
 test('(added, modified) — impossible: logs warning and returns no-op', () => {
@@ -162,10 +151,6 @@ test('multiple paths are each classified independently', () => {
 });
 
 test('no logger provided for impossible cell: still returns no-op without throwing', () => {
-	// Verifies defensive behaviour with no logger passed
-	expect(() => {
-		classify(makeLocal('a.md', 'added'), makeRemote('a.md', 'modified'), EMPTY_STATE);
-	}).not.toThrow();
 	const result = classify(makeLocal('a.md', 'added'), makeRemote('a.md', 'modified'), EMPTY_STATE);
 	expect(result[0].action).toBe('no-op');
 });

--- a/tests/classifier.test.ts
+++ b/tests/classifier.test.ts
@@ -1,0 +1,171 @@
+import { describe, test, expect, vi } from 'vitest';
+import { classify } from '../src/classifier';
+import type { LocalChange, RemoteChange } from '../src/sync-engine-types';
+import type { SyncState } from '../src/state-store';
+
+// Minimal SyncState for tests — classify() doesn't read state fields
+const EMPTY_STATE: SyncState = {
+	schemaVersion: 1,
+	lastSyncCommitSha: 'abc123',
+	lastSyncAt: '2026-01-01T00:00:00Z',
+	files: {},
+};
+
+function makeLocal(path: string, type: LocalChange['type'], contentHash = 'hash-local'): Map<string, LocalChange> {
+	return new Map([[path, { path, type, contentHash, size: 10, isBinary: false }]]);
+}
+
+function makeRemote(path: string, type: RemoteChange['type'], blobSha = 'blobsha-remote'): Map<string, RemoteChange> {
+	return new Map([[path, { path, type, blobSha, size: 10, isBinary: false }]]);
+}
+
+function makeLogger() {
+	const warns: Array<[string, Record<string, unknown> | undefined]> = [];
+	return {
+		warn: vi.fn((event: string, data?: Record<string, unknown>) => { warns.push([event, data]); }),
+		warns,
+	};
+}
+
+const EMPTY = new Map<string, LocalChange>();
+const EMPTY_REMOTE = new Map<string, RemoteChange>();
+
+// ─── Row: local=unchanged ───────────────────────────────────────────────────
+
+test('(unchanged, unchanged) — no-op (path in neither map, not returned)', () => {
+	// A path in neither map is never included in the result
+	const result = classify(EMPTY, EMPTY_REMOTE, EMPTY_STATE);
+	expect(result).toHaveLength(0);
+});
+
+test('(unchanged, added) — pull', () => {
+	const result = classify(EMPTY, makeRemote('a.md', 'added'), EMPTY_STATE);
+	expect(result).toHaveLength(1);
+	expect(result[0]).toMatchObject({ path: 'a.md', action: 'pull', local: 'unchanged', remote: 'added' });
+});
+
+test('(unchanged, modified) — pull', () => {
+	const result = classify(EMPTY, makeRemote('a.md', 'modified'), EMPTY_STATE);
+	expect(result[0]).toMatchObject({ action: 'pull', local: 'unchanged', remote: 'modified' });
+});
+
+test('(unchanged, deleted) — pull', () => {
+	const result = classify(EMPTY, makeRemote('a.md', 'deleted'), EMPTY_STATE);
+	expect(result[0]).toMatchObject({ action: 'pull', local: 'unchanged', remote: 'deleted' });
+});
+
+// ─── Row: local=added ────────────────────────────────────────────────────────
+
+test('(added, unchanged) — push', () => {
+	const result = classify(makeLocal('a.md', 'added'), EMPTY_REMOTE, EMPTY_STATE);
+	expect(result[0]).toMatchObject({ action: 'push', local: 'added', remote: 'unchanged' });
+});
+
+test('(added, added) — conflict (hash comparison deferred to pull phase)', () => {
+	const result = classify(makeLocal('a.md', 'added', 'hash-x'), makeRemote('a.md', 'added', 'blobsha-x'), EMPTY_STATE);
+	expect(result[0]).toMatchObject({ action: 'conflict', local: 'added', remote: 'added' });
+});
+
+describe('(added, added) same-content escape: classifier returns conflict regardless of hash values', () => {
+	test('with matching content hash values — still conflict (deferred)', () => {
+		// sha256 vs git blob sha1 can't be directly compared; classifier always returns conflict
+		const result = classify(makeLocal('a.md', 'added', 'same'), makeRemote('a.md', 'added', 'same'), EMPTY_STATE);
+		expect(result[0]).toMatchObject({ action: 'conflict' });
+	});
+
+	test('with differing hash values — conflict', () => {
+		const result = classify(makeLocal('a.md', 'added', 'hash-a'), makeRemote('a.md', 'added', 'hash-b'), EMPTY_STATE);
+		expect(result[0]).toMatchObject({ action: 'conflict' });
+	});
+});
+
+test('(added, modified) — impossible: logs warning and returns no-op', () => {
+	const logger = makeLogger();
+	const result = classify(makeLocal('a.md', 'added'), makeRemote('a.md', 'modified'), EMPTY_STATE, logger);
+	expect(result[0]).toMatchObject({ action: 'no-op', local: 'added', remote: 'modified' });
+	expect(logger.warn).toHaveBeenCalledWith('classifier:impossible-cell', expect.objectContaining({ path: 'a.md' }));
+});
+
+test('(added, deleted) — impossible: logs warning and returns no-op', () => {
+	const logger = makeLogger();
+	const result = classify(makeLocal('a.md', 'added'), makeRemote('a.md', 'deleted'), EMPTY_STATE, logger);
+	expect(result[0]).toMatchObject({ action: 'no-op', local: 'added', remote: 'deleted' });
+	expect(logger.warn).toHaveBeenCalledWith('classifier:impossible-cell', expect.objectContaining({ path: 'a.md' }));
+});
+
+// ─── Row: local=modified ─────────────────────────────────────────────────────
+
+test('(modified, unchanged) — push', () => {
+	const result = classify(makeLocal('a.md', 'modified'), EMPTY_REMOTE, EMPTY_STATE);
+	expect(result[0]).toMatchObject({ action: 'push', local: 'modified', remote: 'unchanged' });
+});
+
+test('(modified, added) — impossible: logs warning and returns no-op', () => {
+	const logger = makeLogger();
+	const result = classify(makeLocal('a.md', 'modified'), makeRemote('a.md', 'added'), EMPTY_STATE, logger);
+	expect(result[0]).toMatchObject({ action: 'no-op', local: 'modified', remote: 'added' });
+	expect(logger.warn).toHaveBeenCalledWith('classifier:impossible-cell', expect.objectContaining({ path: 'a.md' }));
+});
+
+test('(modified, modified) — conflict', () => {
+	const result = classify(makeLocal('a.md', 'modified'), makeRemote('a.md', 'modified'), EMPTY_STATE);
+	expect(result[0]).toMatchObject({ action: 'conflict', local: 'modified', remote: 'modified' });
+});
+
+test('(modified, deleted) — conflict', () => {
+	const result = classify(makeLocal('a.md', 'modified'), makeRemote('a.md', 'deleted'), EMPTY_STATE);
+	expect(result[0]).toMatchObject({ action: 'conflict', local: 'modified', remote: 'deleted' });
+});
+
+// ─── Row: local=deleted ──────────────────────────────────────────────────────
+
+test('(deleted, unchanged) — push', () => {
+	const result = classify(makeLocal('a.md', 'deleted'), EMPTY_REMOTE, EMPTY_STATE);
+	expect(result[0]).toMatchObject({ action: 'push', local: 'deleted', remote: 'unchanged' });
+});
+
+test('(deleted, added) — impossible: logs warning and returns no-op', () => {
+	const logger = makeLogger();
+	const result = classify(makeLocal('a.md', 'deleted'), makeRemote('a.md', 'added'), EMPTY_STATE, logger);
+	expect(result[0]).toMatchObject({ action: 'no-op', local: 'deleted', remote: 'added' });
+	expect(logger.warn).toHaveBeenCalledWith('classifier:impossible-cell', expect.objectContaining({ path: 'a.md' }));
+});
+
+test('(deleted, modified) — conflict', () => {
+	const result = classify(makeLocal('a.md', 'deleted'), makeRemote('a.md', 'modified'), EMPTY_STATE);
+	expect(result[0]).toMatchObject({ action: 'conflict', local: 'deleted', remote: 'modified' });
+});
+
+test('(deleted, deleted) — no-op', () => {
+	const result = classify(makeLocal('a.md', 'deleted'), makeRemote('a.md', 'deleted'), EMPTY_STATE);
+	expect(result[0]).toMatchObject({ action: 'no-op', local: 'deleted', remote: 'deleted' });
+});
+
+// ─── Multiple paths ───────────────────────────────────────────────────────────
+
+test('multiple paths are each classified independently', () => {
+	const localChanges: Map<string, LocalChange> = new Map([
+		['added.md', { path: 'added.md', type: 'added', contentHash: 'h1', size: 5, isBinary: false }],
+		['modified.md', { path: 'modified.md', type: 'modified', contentHash: 'h2', size: 5, isBinary: false }],
+	]);
+	const remoteChanges: Map<string, RemoteChange> = new Map([
+		['remote-added.md', { path: 'remote-added.md', type: 'added', blobSha: 'b1', size: 5, isBinary: false }],
+	]);
+
+	const result = classify(localChanges, remoteChanges, EMPTY_STATE);
+	expect(result).toHaveLength(3);
+
+	const byPath = Object.fromEntries(result.map(r => [r.path, r]));
+	expect(byPath['added.md'].action).toBe('push');
+	expect(byPath['modified.md'].action).toBe('push');
+	expect(byPath['remote-added.md'].action).toBe('pull');
+});
+
+test('no logger provided for impossible cell: still returns no-op without throwing', () => {
+	// Verifies defensive behaviour with no logger passed
+	expect(() => {
+		classify(makeLocal('a.md', 'added'), makeRemote('a.md', 'modified'), EMPTY_STATE);
+	}).not.toThrow();
+	const result = classify(makeLocal('a.md', 'added'), makeRemote('a.md', 'modified'), EMPTY_STATE);
+	expect(result[0].action).toBe('no-op');
+});


### PR DESCRIPTION
## Summary
Introduces a new `classifier` module that determines the appropriate sync action (pull, push, conflict, or no-op) for each file based on local and remote changes. This is a foundational component for the sync engine's conflict resolution strategy.

## Key Changes
- **New `classifier.ts` module**: Implements the `classify()` function that takes local changes, remote changes, and sync state, then returns a list of classified paths with their recommended actions
- **Classification logic**: Uses a decision matrix to resolve actions:
  - `pull`: Remote changed, local unchanged
  - `push`: Local changed, remote unchanged
  - `conflict`: Both sides changed (hash comparison deferred to pull phase for added files)
  - `no-op`: Neither changed, or both deleted
  - Logs warnings for impossible state combinations (e.g., remote added when path exists in state)
- **Type updates**: Added `ClassifyAction` type and `action` field to `ClassifiedPath` interface in `sync-engine-types.ts`
- **Comprehensive test suite**: 171 lines of tests covering all 16 state combinations (4 local states × 4 remote states) plus multi-path scenarios and edge cases

## Notable Implementation Details
- The classifier treats local and remote changes symmetrically for impossible states (e.g., a path can't be both added locally and modified remotely if it exists in sync state)
- Hash comparison for conflicting additions is intentionally deferred to the pull phase, as local content uses SHA256 while remote uses git blob SHA1
- Logger is optional; the function gracefully handles missing logger without throwing
- Paths that appear in neither local nor remote changes are not included in results (true no-ops are omitted)

https://claude.ai/code/session_01Y4rWPaM6NKK6uMRDkhGDuc