### PR TITLE
Implement applyPull for the pull phase of sync

### DIFF
--- a/src/apply-pull.ts
+++ b/src/apply-pull.ts
@@ -1,10 +1,11 @@
-import type { ClassifiedPath, VaultAdapter } from './sync-engine-types';
-import type { RemoteChange } from './sync-engine-types';
+import type { ClassifiedPath, VaultAdapter, RemoteChange } from './sync-engine-types';
 import type { SyncState, SyncedFileRecord } from './state-store';
 import type { Settings } from './settings';
 import type { GitHubClient } from './github-client';
 import { SyncStateInconsistencyError } from './sync-engine-types';
 import { sha256 } from './hash';
+
+const decoder = new TextDecoder();
 
 export interface PullLogger {
 	debug(event: string, data?: Record<string, unknown>): Promise<void>;
@@ -41,7 +42,7 @@ export async function applyPull(
 			if (remoteChange.isBinary) {
 				await vault.writeBinary(path, bytes);
 			} else {
-				await vault.writeText(path, new TextDecoder().decode(bytes));
+				await vault.writeText(path, decoder.decode(bytes));
 			}
 
 			const contentHash = await sha256(bytes);

--- a/src/apply-pull.ts
+++ b/src/apply-pull.ts
@@ -1,0 +1,76 @@
+import type { ClassifiedPath, VaultAdapter } from './sync-engine-types';
+import type { RemoteChange } from './sync-engine-types';
+import type { SyncState, SyncedFileRecord } from './state-store';
+import type { Settings } from './settings';
+import type { GitHubClient } from './github-client';
+import { SyncStateInconsistencyError } from './sync-engine-types';
+import { sha256 } from './hash';
+
+export interface PullLogger {
+	debug(event: string, data?: Record<string, unknown>): Promise<void>;
+	warn(event: string, data?: Record<string, unknown>): Promise<void>;
+	error(event: string, data?: Record<string, unknown>): Promise<void>;
+}
+
+export async function applyPull(
+	paths: ClassifiedPath[],
+	remote: Map<string, RemoteChange>,
+	client: GitHubClient,
+	vault: VaultAdapter,
+	state: SyncState,
+	settings: Settings,
+	logger: PullLogger,
+): Promise<{ updatedState: SyncState; skipped: string[] }> {
+	const skipped: string[] = [];
+	const sizeLimitBytes = settings.perFileSizeLimitMb * 1024 * 1024;
+
+	for (const classified of paths) {
+		const { path } = classified;
+		const remoteChange = remote.get(path);
+		if (!remoteChange || remoteChange.type === 'unchanged') continue;
+
+		if (remoteChange.type === 'added' || remoteChange.type === 'modified') {
+			if (remoteChange.size > sizeLimitBytes) {
+				await logger.warn('sync.pull.file', { path, reason: 'size-limit', size: remoteChange.size });
+				skipped.push(path);
+				continue;
+			}
+
+			const bytes = await client.getBlob(settings.owner, settings.repo, remoteChange.blobSha!);
+
+			if (remoteChange.isBinary) {
+				await vault.writeBinary(path, bytes);
+			} else {
+				await vault.writeText(path, new TextDecoder().decode(bytes));
+			}
+
+			const contentHash = await sha256(bytes);
+			const record: SyncedFileRecord = {
+				path,
+				blobSha: remoteChange.blobSha!,
+				contentHash,
+				size: remoteChange.size,
+				isBinary: remoteChange.isBinary,
+			};
+			state.files[path] = record;
+
+			await logger.debug('sync.pull.file', { path, type: remoteChange.type });
+		} else {
+			// remote-deleted
+			const localBytes = await vault.readBinary(path);
+			const localHash = await sha256(localBytes);
+
+			if (localHash !== state.files[path]?.contentHash) {
+				await logger.error('sync.pull.file', { path, reason: 'hash-mismatch' });
+				throw new SyncStateInconsistencyError(path);
+			}
+
+			await vault.delete(path);
+			delete state.files[path];
+
+			await logger.debug('sync.pull.file', { path, type: 'deleted' });
+		}
+	}
+
+	return { updatedState: state, skipped };
+}

--- a/src/sync-engine-types.ts
+++ b/src/sync-engine-types.ts
@@ -80,6 +80,15 @@ export class SyncNeedsUIError extends Error {
 	}
 }
 
+export class SyncStateInconsistencyError extends Error {
+	override readonly name = 'SyncStateInconsistencyError';
+	readonly path: string;
+	constructor(path: string) {
+		super(`Hash mismatch on remote-deleted path '${path}': local file modified outside of sync.`);
+		this.path = path;
+	}
+}
+
 export class PolicyBasedResolver implements ConflictResolver, FirstSyncResolver {
 	constructor(private readonly policy: 'always-prefer-local' | 'always-prefer-remote' | 'always-ask') {}
 

--- a/tests/apply-pull.test.ts
+++ b/tests/apply-pull.test.ts
@@ -1,0 +1,263 @@
+import { describe, test, expect, vi, type Mock } from 'vitest';
+import { applyPull, type PullLogger } from '../src/apply-pull';
+import { SyncStateInconsistencyError } from '../src/sync-engine-types';
+import type { ClassifiedPath, VaultAdapter } from '../src/sync-engine-types';
+import type { RemoteChange } from '../src/sync-engine-types';
+import type { SyncState } from '../src/state-store';
+import type { Settings } from '../src/settings';
+import type { GitHubClient } from '../src/github-client';
+import { sha256 } from '../src/hash';
+
+function toBytes(s: string): ArrayBuffer {
+	return new TextEncoder().encode(s).buffer as ArrayBuffer;
+}
+
+interface MockClient {
+	getBlob: Mock;
+}
+
+function makeClient(): MockClient {
+	return { getBlob: vi.fn() };
+}
+
+function asClient(mock: MockClient): GitHubClient {
+	return mock as unknown as GitHubClient;
+}
+
+interface MockVault {
+	readBinary: Mock;
+	readText: Mock;
+	writeText: Mock;
+	writeBinary: Mock;
+	delete: Mock;
+	listFiles: Mock;
+	listDirectory: Mock;
+	exists: Mock;
+}
+
+function makeVault(): MockVault {
+	return {
+		readBinary: vi.fn(),
+		readText: vi.fn(),
+		writeText: vi.fn().mockResolvedValue(undefined),
+		writeBinary: vi.fn().mockResolvedValue(undefined),
+		delete: vi.fn().mockResolvedValue(undefined),
+		listFiles: vi.fn(),
+		listDirectory: vi.fn(),
+		exists: vi.fn(),
+	};
+}
+
+function asVault(mock: MockVault): VaultAdapter {
+	return mock as unknown as VaultAdapter;
+}
+
+function makeLogger(): MockLogger & PullLogger {
+	return {
+		debug: vi.fn().mockResolvedValue(undefined),
+		warn: vi.fn().mockResolvedValue(undefined),
+		error: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+interface MockLogger {
+	debug: Mock;
+	warn: Mock;
+	error: Mock;
+}
+
+function makeState(overrides: Partial<SyncState> = {}): SyncState {
+	return {
+		schemaVersion: 1,
+		lastSyncCommitSha: 'abc123',
+		lastSyncAt: '2026-04-29T00:00:00.000Z',
+		files: {},
+		...overrides,
+	};
+}
+
+function makeSettings(overrides: Partial<Settings> = {}): Settings {
+	return {
+		owner: 'test-owner',
+		repo: 'test-repo',
+		branch: 'main',
+		pat: 'test-pat',
+		conflictPolicy: 'always-ask',
+		perFileSizeLimitMb: 25,
+		deviceName: 'test',
+		includeObsidianConfig: false,
+		excludePatterns: [],
+		verboseLogging: false,
+		...overrides,
+	};
+}
+
+function makeClassified(
+	path: string,
+	action: ClassifiedPath['action'],
+	remote: ClassifiedPath['remote'],
+	local: ClassifiedPath['local'] = 'unchanged',
+): ClassifiedPath {
+	return { path, action, remote, local };
+}
+
+describe('applyPull', () => {
+	test('remote-added text file: fetches blob, writes text, updates state', async () => {
+		const path = 'notes/hello.md';
+		const blobSha = 'blob-sha-abc';
+		const content = 'Hello, world!';
+		const bytes = toBytes(content);
+
+		const client = makeClient();
+		client.getBlob.mockResolvedValue(bytes);
+		const vault = makeVault();
+		const logger = makeLogger();
+		const state = makeState();
+		const settings = makeSettings();
+
+		const remote = new Map<string, RemoteChange>([
+			[path, { path, type: 'added', blobSha, size: bytes.byteLength, isBinary: false }],
+		]);
+		const paths = [makeClassified(path, 'pull', 'added')];
+
+		const result = await applyPull(paths, remote, asClient(client), asVault(vault), state, settings, logger);
+
+		expect(client.getBlob).toHaveBeenCalledWith('test-owner', 'test-repo', blobSha);
+		expect(vault.writeText).toHaveBeenCalledWith(path, content);
+		expect(vault.writeBinary).not.toHaveBeenCalled();
+
+		const expectedHash = await sha256(bytes);
+		expect(result.updatedState.files[path]).toEqual({
+			path,
+			blobSha,
+			contentHash: expectedHash,
+			size: bytes.byteLength,
+			isBinary: false,
+		});
+		expect(result.skipped).toEqual([]);
+	});
+
+	test('remote-modified binary file: fetches blob, writes binary, updates state', async () => {
+		const path = 'images/photo.png';
+		const blobSha = 'blob-sha-binary';
+		const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]).buffer as ArrayBuffer;
+
+		const client = makeClient();
+		client.getBlob.mockResolvedValue(bytes);
+		const vault = makeVault();
+		const logger = makeLogger();
+		const state = makeState({
+			files: {
+				[path]: { path, blobSha: 'old-blob-sha', contentHash: 'old-hash', size: 100, isBinary: true },
+			},
+		});
+		const settings = makeSettings();
+
+		const remote = new Map<string, RemoteChange>([
+			[path, { path, type: 'modified', blobSha, size: bytes.byteLength, isBinary: true }],
+		]);
+		const paths = [makeClassified(path, 'pull', 'modified')];
+
+		const result = await applyPull(paths, remote, asClient(client), asVault(vault), state, settings, logger);
+
+		expect(client.getBlob).toHaveBeenCalledWith('test-owner', 'test-repo', blobSha);
+		expect(vault.writeBinary).toHaveBeenCalledWith(path, bytes);
+		expect(vault.writeText).not.toHaveBeenCalled();
+
+		const expectedHash = await sha256(bytes);
+		expect(result.updatedState.files[path]).toEqual({
+			path,
+			blobSha,
+			contentHash: expectedHash,
+			size: bytes.byteLength,
+			isBinary: true,
+		});
+		expect(result.skipped).toEqual([]);
+	});
+
+	test('remote-deleted with matching hash: deletes file, clears state entry', async () => {
+		const path = 'notes/old.md';
+		const content = 'Old content';
+		const bytes = toBytes(content);
+		const contentHash = await sha256(bytes);
+
+		const client = makeClient();
+		const vault = makeVault();
+		vault.readBinary.mockResolvedValue(bytes);
+		const logger = makeLogger();
+		const state = makeState({
+			files: {
+				[path]: { path, blobSha: 'old-blob', contentHash, size: bytes.byteLength, isBinary: false },
+			},
+		});
+		const settings = makeSettings();
+
+		const remote = new Map<string, RemoteChange>([
+			[path, { path, type: 'deleted', size: 0, isBinary: false }],
+		]);
+		const paths = [makeClassified(path, 'pull', 'deleted')];
+
+		const result = await applyPull(paths, remote, asClient(client), asVault(vault), state, settings, logger);
+
+		expect(vault.readBinary).toHaveBeenCalledWith(path);
+		expect(vault.delete).toHaveBeenCalledWith(path);
+		expect(result.updatedState.files[path]).toBeUndefined();
+		expect(client.getBlob).not.toHaveBeenCalled();
+		expect(result.skipped).toEqual([]);
+	});
+
+	test('remote-deleted with mismatched hash: throws SyncStateInconsistencyError', async () => {
+		const path = 'notes/changed.md';
+		const originalBytes = toBytes('original content');
+		const originalHash = await sha256(originalBytes);
+		const modifiedBytes = toBytes('locally modified content');
+
+		const client = makeClient();
+		const vault = makeVault();
+		vault.readBinary.mockResolvedValue(modifiedBytes);
+		const logger = makeLogger();
+		const state = makeState({
+			files: {
+				[path]: { path, blobSha: 'old-blob', contentHash: originalHash, size: originalBytes.byteLength, isBinary: false },
+			},
+		});
+		const settings = makeSettings();
+
+		const remote = new Map<string, RemoteChange>([
+			[path, { path, type: 'deleted', size: 0, isBinary: false }],
+		]);
+		const paths = [makeClassified(path, 'pull', 'deleted')];
+
+		await expect(
+			applyPull(paths, remote, asClient(client), asVault(vault), state, settings, logger),
+		).rejects.toThrow(SyncStateInconsistencyError);
+
+		expect(vault.delete).not.toHaveBeenCalled();
+		expect(logger.error).toHaveBeenCalled();
+	});
+
+	test('file exceeding size limit: added to skipped, blob not fetched', async () => {
+		const path = 'large/video.mp4';
+		const blobSha = 'blob-sha-large';
+		const sizeBytes = 30 * 1024 * 1024; // 30 MB, exceeds 25 MB limit
+
+		const client = makeClient();
+		const vault = makeVault();
+		const logger = makeLogger();
+		const state = makeState();
+		const settings = makeSettings({ perFileSizeLimitMb: 25 });
+
+		const remote = new Map<string, RemoteChange>([
+			[path, { path, type: 'added', blobSha, size: sizeBytes, isBinary: true }],
+		]);
+		const paths = [makeClassified(path, 'pull', 'added')];
+
+		const result = await applyPull(paths, remote, asClient(client), asVault(vault), state, settings, logger);
+
+		expect(client.getBlob).not.toHaveBeenCalled();
+		expect(vault.writeBinary).not.toHaveBeenCalled();
+		expect(result.skipped).toEqual([path]);
+		expect(logger.warn).toHaveBeenCalled();
+		expect(result.updatedState.files[path]).toBeUndefined();
+	});
+});

--- a/tests/apply-pull.test.ts
+++ b/tests/apply-pull.test.ts
@@ -1,8 +1,7 @@
 import { describe, test, expect, vi, type Mock } from 'vitest';
 import { applyPull, type PullLogger } from '../src/apply-pull';
 import { SyncStateInconsistencyError } from '../src/sync-engine-types';
-import type { ClassifiedPath, VaultAdapter } from '../src/sync-engine-types';
-import type { RemoteChange } from '../src/sync-engine-types';
+import type { ClassifiedPath, VaultAdapter, RemoteChange } from '../src/sync-engine-types';
 import type { SyncState } from '../src/state-store';
 import type { Settings } from '../src/settings';
 import type { GitHubClient } from '../src/github-client';
@@ -52,18 +51,18 @@ function asVault(mock: MockVault): VaultAdapter {
 	return mock as unknown as VaultAdapter;
 }
 
+interface MockLogger {
+	debug: Mock;
+	warn: Mock;
+	error: Mock;
+}
+
 function makeLogger(): MockLogger & PullLogger {
 	return {
 		debug: vi.fn().mockResolvedValue(undefined),
 		warn: vi.fn().mockResolvedValue(undefined),
 		error: vi.fn().mockResolvedValue(undefined),
 	};
-}
-
-interface MockLogger {
-	debug: Mock;
-	warn: Mock;
-	error: Mock;
 }
 
 function makeState(overrides: Partial<SyncState> = {}): SyncState {
@@ -125,6 +124,7 @@ describe('applyPull', () => {
 		expect(client.getBlob).toHaveBeenCalledWith('test-owner', 'test-repo', blobSha);
 		expect(vault.writeText).toHaveBeenCalledWith(path, content);
 		expect(vault.writeBinary).not.toHaveBeenCalled();
+		expect(logger.debug).toHaveBeenCalledWith('sync.pull.file', { path, type: 'added' });
 
 		const expectedHash = await sha256(bytes);
 		expect(result.updatedState.files[path]).toEqual({
@@ -163,6 +163,7 @@ describe('applyPull', () => {
 		expect(client.getBlob).toHaveBeenCalledWith('test-owner', 'test-repo', blobSha);
 		expect(vault.writeBinary).toHaveBeenCalledWith(path, bytes);
 		expect(vault.writeText).not.toHaveBeenCalled();
+		expect(logger.debug).toHaveBeenCalledWith('sync.pull.file', { path, type: 'modified' });
 
 		const expectedHash = await sha256(bytes);
 		expect(result.updatedState.files[path]).toEqual({
@@ -204,6 +205,7 @@ describe('applyPull', () => {
 		expect(result.updatedState.files[path]).toBeUndefined();
 		expect(client.getBlob).not.toHaveBeenCalled();
 		expect(result.skipped).toEqual([]);
+		expect(logger.debug).toHaveBeenCalledWith('sync.pull.file', { path, type: 'deleted' });
 	});
 
 	test('remote-deleted with mismatched hash: throws SyncStateInconsistencyError', async () => {
@@ -245,7 +247,7 @@ describe('applyPull', () => {
 		const vault = makeVault();
 		const logger = makeLogger();
 		const state = makeState();
-		const settings = makeSettings({ perFileSizeLimitMb: 25 });
+		const settings = makeSettings();
 
 		const remote = new Map<string, RemoteChange>([
 			[path, { path, type: 'added', blobSha, size: sizeBytes, isBinary: true }],
@@ -259,5 +261,44 @@ describe('applyPull', () => {
 		expect(result.skipped).toEqual([path]);
 		expect(logger.warn).toHaveBeenCalled();
 		expect(result.updatedState.files[path]).toBeUndefined();
+	});
+
+	test('keep-remote conflict resolution: fetches and writes blob, updates state', async () => {
+		const path = 'notes/conflict.md';
+		const blobSha = 'blob-sha-conflict';
+		const content = 'Remote wins';
+		const bytes = toBytes(content);
+
+		const client = makeClient();
+		client.getBlob.mockResolvedValue(bytes);
+		const vault = makeVault();
+		const logger = makeLogger();
+		const state = makeState({
+			files: {
+				[path]: { path, blobSha: 'old-blob', contentHash: 'old-hash', size: 50, isBinary: false },
+			},
+		});
+		const settings = makeSettings();
+
+		const remote = new Map<string, RemoteChange>([
+			[path, { path, type: 'modified', blobSha, size: bytes.byteLength, isBinary: false }],
+		]);
+		// action is 'conflict' but caller resolved it as keep-remote, so it's in the paths list
+		const paths = [makeClassified(path, 'conflict', 'modified', 'modified')];
+
+		const result = await applyPull(paths, remote, asClient(client), asVault(vault), state, settings, logger);
+
+		expect(client.getBlob).toHaveBeenCalledWith('test-owner', 'test-repo', blobSha);
+		expect(vault.writeText).toHaveBeenCalledWith(path, content);
+
+		const expectedHash = await sha256(bytes);
+		expect(result.updatedState.files[path]).toEqual({
+			path,
+			blobSha,
+			contentHash: expectedHash,
+			size: bytes.byteLength,
+			isBinary: false,
+		});
+		expect(result.skipped).toEqual([]);
 	});
 });


### PR DESCRIPTION
Adds applyPull() which downloads remote blobs and writes them to the vault,
handles remote deletions with a hash guard, enforces per-file size limits,
and mutates the in-memory SyncState for each pulled path.

Also adds SyncStateInconsistencyError for the hash-mismatch case on remote-deleted paths.

Closes #43

https://claude.ai/code/session_013qitkYsNDKHjN76ByEjsfx