### PR TITLE
Add ribbon icon, command palette entry, and status bar (issue #65)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,8 @@
 import { Notice, Platform, Plugin } from 'obsidian';
 import { Settings, DEFAULT_SETTINGS } from './settings';
 import { JackdawSettingsTab } from './ui/settings-tab';
+import { RibbonIcon } from './ui/ribbon';
+import { StatusBar } from './ui/status-bar';
 
 export default class JackdawPlugin extends Plugin {
 	settings!: Settings;
@@ -15,16 +17,29 @@ export default class JackdawPlugin extends Plugin {
 
 		this.addSettingTab(new JackdawSettingsTab(this.app, this));
 
-		this.addRibbonIcon('sync', 'Jackdaw: Sync vault', () => {
-			new Notice('Sync coming soon');
-		});
+		let statusBar: StatusBar | undefined;
+		if (!Platform.isMobileApp) {
+			statusBar = new StatusBar(this.addStatusBarItem());
+		}
+
+		const syncAction = async (): Promise<void> => {
+			ribbon.setSyncing();
+			statusBar?.setSyncing();
+			try {
+				// TODO: wire sync engine
+				new Notice('Jackdaw: Sync coming soon');
+			} finally {
+				ribbon.setIdle();
+				statusBar?.setIdle(null);
+			}
+		};
+
+		const ribbon = new RibbonIcon(this, syncAction);
 
 		this.addCommand({
 			id: 'sync-vault',
-			name: 'Sync vault',
-			callback: () => {
-				new Notice('Sync coming soon');
-			},
+			name: 'Sync with GitHub',
+			callback: syncAction,
 		});
 	}
 

--- a/src/ui/ribbon.ts
+++ b/src/ui/ribbon.ts
@@ -1,0 +1,17 @@
+import { Plugin } from 'obsidian';
+
+export class RibbonIcon {
+	private el: HTMLElement;
+
+	constructor(plugin: Plugin, onClick: () => void) {
+		this.el = plugin.addRibbonIcon('refresh-cw', 'Jackdaw: Sync vault', onClick);
+	}
+
+	setSyncing(): void {
+		this.el.addClass('jackdaw-syncing');
+	}
+
+	setIdle(): void {
+		this.el.removeClass('jackdaw-syncing');
+	}
+}

--- a/src/ui/status-bar.ts
+++ b/src/ui/status-bar.ts
@@ -1,0 +1,31 @@
+export class StatusBar {
+	private el: HTMLElement;
+
+	constructor(el: HTMLElement) {
+		this.el = el;
+		this.setIdle(null);
+	}
+
+	setIdle(lastSyncAt: string | null): void {
+		if (lastSyncAt === null) {
+			this.el.setText('Jackdaw: Never synced');
+		} else {
+			const time = new Date(lastSyncAt).toLocaleTimeString([], {
+				hour: '2-digit',
+				minute: '2-digit',
+			});
+			this.el.setText(`Jackdaw: Synced ${time}`);
+		}
+		this.el.removeAttribute('aria-label');
+	}
+
+	setSyncing(): void {
+		this.el.setText('Jackdaw: Syncing…');
+		this.el.removeAttribute('aria-label');
+	}
+
+	setError(message: string): void {
+		this.el.setText('Jackdaw: Sync error');
+		this.el.setAttribute('aria-label', message);
+	}
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,6 @@
+.jackdaw-syncing svg {
+  animation: jackdaw-spin 1s linear infinite;
+}
+@keyframes jackdaw-spin {
+  to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
Implements the three sync triggers and status indicator per §8.2:
- src/ui/ribbon.ts: RibbonIcon class with jackdaw-syncing CSS toggle
- src/ui/status-bar.ts: StatusBar class with setIdle/setSyncing/setError API
- src/main.ts: wires ribbon, command, and status bar around a sync action stub
- styles.css: spin animation for the syncing ribbon icon

Closes #65

https://claude.ai/code/session_01MnNXu6rJFAMeir3aTL13tz