### PR TITLE
Implement §4.4 staleness detection in classifier

### DIFF
--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -1,5 +1,6 @@
 import type { LocalChange, RemoteChange, LocalChangeType, RemoteChangeType, ClassifyAction, ClassifiedPath } from './sync-engine-types';
 import type { SyncState } from './state-store';
+import { gitBlobSha1 } from './hash';
 
 // Intentionally sync — classify() is pure with no I/O. Callers using the async
 // Logger from state-store.ts need to wrap it (e.g. (e, d) => void logger.warn(e, d)).
@@ -7,19 +8,30 @@ export interface ClassifierLogger {
 	warn(event: string, data?: Record<string, unknown>): void;
 }
 
-export function classify(
+export async function classify(
 	localChanges: Map<string, LocalChange>,
 	remoteChanges: Map<string, RemoteChange>,
-	_state: SyncState, // reserved — staleness comparison (§4.4) is deferred to the pull phase
+	_state: SyncState,
 	logger?: ClassifierLogger,
-): ClassifiedPath[] {
+): Promise<ClassifiedPath[]> {
 	const allPaths = new Set([...localChanges.keys(), ...remoteChanges.keys()]);
 	const result: ClassifiedPath[] = [];
 
 	for (const path of allPaths) {
-		const localType: LocalChangeType = localChanges.get(path)?.type ?? 'unchanged';
-		const remoteType: RemoteChangeType = remoteChanges.get(path)?.type ?? 'unchanged';
-		const action = resolveAction(localType, remoteType, path, logger);
+		const localChange = localChanges.get(path);
+		const remoteChange = remoteChanges.get(path);
+		const localType: LocalChangeType = localChange?.type ?? 'unchanged';
+		const remoteType: RemoteChangeType = remoteChange?.type ?? 'unchanged';
+		let action = resolveAction(localType, remoteType, path, logger);
+
+		// §4.4 staleness: both sides differ from state but local content matches remote
+		if (action === 'conflict' && localChange?.bytes && remoteChange?.blobSha) {
+			const localBlobSha = await gitBlobSha1(localChange.bytes);
+			if (localBlobSha === remoteChange.blobSha) {
+				action = 'state-refresh';
+			}
+		}
+
 		result.push({ path, action, local: localType, remote: remoteType });
 	}
 

--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -2,8 +2,8 @@ import type { LocalChange, RemoteChange, LocalChangeType, RemoteChangeType, Clas
 import type { SyncState } from './state-store';
 import { gitBlobSha1 } from './hash';
 
-// Intentionally sync — classify() is pure with no I/O. Callers using the async
-// Logger from state-store.ts need to wrap it (e.g. (e, d) => void logger.warn(e, d)).
+// ClassifierLogger is sync so classify() callers can wrap an async logger inline
+// (e.g. (e, d) => void logger.warn(e, d)).
 export interface ClassifierLogger {
 	warn(event: string, data?: Record<string, unknown>): void;
 }

--- a/src/sync-engine-types.ts
+++ b/src/sync-engine-types.ts
@@ -18,7 +18,7 @@ export interface RemoteChange {
 	isBinary: boolean;
 }
 
-export type ClassifyAction = 'pull' | 'push' | 'conflict' | 'no-op';
+export type ClassifyAction = 'pull' | 'push' | 'conflict' | 'no-op' | 'state-refresh';
 
 export interface ClassifiedPath {
 	path: string;

--- a/src/sync-engine.ts
+++ b/src/sync-engine.ts
@@ -118,7 +118,22 @@ export class SyncEngine {
 					void this.logger.warn(event, data);
 				},
 			};
-			const classified = classify(local, remote, syncState, classifierLogger);
+			const classified = await classify(local, remote, syncState, classifierLogger);
+
+			// §4.4: update state for paths where local content matches remote (staleness)
+			for (const item of classified) {
+				if (item.action !== 'state-refresh') continue;
+				const localChange = local.get(item.path);
+				const remoteChange = remote.get(item.path);
+				if (!localChange || !remoteChange?.blobSha) continue;
+				syncState.files[item.path] = {
+					path: item.path,
+					blobSha: remoteChange.blobSha,
+					contentHash: localChange.contentHash,
+					size: localChange.size,
+					isBinary: localChange.isBinary,
+				};
+			}
 
 			// Detect and resolve conflicts
 			const conflictItems = classified.filter((c): c is ConflictItem => c.action === 'conflict');

--- a/tests/classifier.test.ts
+++ b/tests/classifier.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, vi } from 'vitest';
 import { classify } from '../src/classifier';
+import { gitBlobSha1, sha256 } from '../src/hash';
 import type { LocalChange, RemoteChange } from '../src/sync-engine-types';
 import type { SyncState } from '../src/state-store';
 
@@ -23,116 +24,123 @@ function makeLogger() {
 	return { warn: vi.fn<[string, (Record<string, unknown> | undefined)?], void>() };
 }
 
+async function makeStalenessFixture() {
+	const bytes = new TextEncoder().encode('same content on both sides').buffer as ArrayBuffer;
+	const blobSha = await gitBlobSha1(bytes);
+	const contentHash = await sha256(bytes);
+	return { bytes, blobSha, contentHash, size: bytes.byteLength };
+}
+
 const EMPTY = new Map<string, LocalChange>();
 const EMPTY_REMOTE = new Map<string, RemoteChange>();
 
 // ─── Row: local=unchanged ───────────────────────────────────────────────────
 
-test('(unchanged, unchanged) — no-op (path in neither map, not returned)', () => {
+test('(unchanged, unchanged) — no-op (path in neither map, not returned)', async () => {
 	// A path in neither map is never included in the result
-	const result = classify(EMPTY, EMPTY_REMOTE, EMPTY_STATE);
+	const result = await classify(EMPTY, EMPTY_REMOTE, EMPTY_STATE);
 	expect(result).toHaveLength(0);
 });
 
-test('(unchanged, added) — pull', () => {
-	const result = classify(EMPTY, makeRemote('a.md', 'added'), EMPTY_STATE);
+test('(unchanged, added) — pull', async () => {
+	const result = await classify(EMPTY, makeRemote('a.md', 'added'), EMPTY_STATE);
 	expect(result).toHaveLength(1);
 	expect(result[0]).toMatchObject({ path: 'a.md', action: 'pull', local: 'unchanged', remote: 'added' });
 });
 
-test('(unchanged, modified) — pull', () => {
-	const result = classify(EMPTY, makeRemote('a.md', 'modified'), EMPTY_STATE);
+test('(unchanged, modified) — pull', async () => {
+	const result = await classify(EMPTY, makeRemote('a.md', 'modified'), EMPTY_STATE);
 	expect(result[0]).toMatchObject({ action: 'pull', local: 'unchanged', remote: 'modified' });
 });
 
-test('(unchanged, deleted) — pull', () => {
-	const result = classify(EMPTY, makeRemote('a.md', 'deleted'), EMPTY_STATE);
+test('(unchanged, deleted) — pull', async () => {
+	const result = await classify(EMPTY, makeRemote('a.md', 'deleted'), EMPTY_STATE);
 	expect(result[0]).toMatchObject({ action: 'pull', local: 'unchanged', remote: 'deleted' });
 });
 
 // ─── Row: local=added ────────────────────────────────────────────────────────
 
-test('(added, unchanged) — push', () => {
-	const result = classify(makeLocal('a.md', 'added'), EMPTY_REMOTE, EMPTY_STATE);
+test('(added, unchanged) — push', async () => {
+	const result = await classify(makeLocal('a.md', 'added'), EMPTY_REMOTE, EMPTY_STATE);
 	expect(result[0]).toMatchObject({ action: 'push', local: 'added', remote: 'unchanged' });
 });
 
-test('(added, added) — conflict (hash comparison deferred to pull phase)', () => {
-	const result = classify(makeLocal('a.md', 'added', 'hash-x'), makeRemote('a.md', 'added', 'blobsha-x'), EMPTY_STATE);
+test('(added, added) — conflict when no bytes available for staleness check', async () => {
+	// makeLocal omits bytes; staleness check is skipped → conflict
+	const result = await classify(makeLocal('a.md', 'added', 'hash-x'), makeRemote('a.md', 'added', 'blobsha-x'), EMPTY_STATE);
 	expect(result[0]).toMatchObject({ action: 'conflict', local: 'added', remote: 'added' });
 });
 
-test('(added, added) always conflict — sha256 vs git blob sha1 cannot be compared without I/O', () => {
-	// Hash comparison (same-content escape) is deferred to the pull phase; classifier has no I/O
-	const result = classify(makeLocal('a.md', 'added', 'hash-a'), makeRemote('a.md', 'added', 'hash-b'), EMPTY_STATE);
+test('(added, added) — conflict when bytes present but hashes differ', async () => {
+	const result = await classify(makeLocal('a.md', 'added', 'hash-a'), makeRemote('a.md', 'added', 'hash-b'), EMPTY_STATE);
 	expect(result[0]).toMatchObject({ action: 'conflict' });
 });
 
-test('(added, modified) — impossible: logs warning and returns no-op', () => {
+test('(added, modified) — impossible: logs warning and returns no-op', async () => {
 	const logger = makeLogger();
-	const result = classify(makeLocal('a.md', 'added'), makeRemote('a.md', 'modified'), EMPTY_STATE, logger);
+	const result = await classify(makeLocal('a.md', 'added'), makeRemote('a.md', 'modified'), EMPTY_STATE, logger);
 	expect(result[0]).toMatchObject({ action: 'no-op', local: 'added', remote: 'modified' });
 	expect(logger.warn).toHaveBeenCalledWith('classifier:impossible-cell', expect.objectContaining({ path: 'a.md' }));
 });
 
-test('(added, deleted) — impossible: logs warning and returns no-op', () => {
+test('(added, deleted) — impossible: logs warning and returns no-op', async () => {
 	const logger = makeLogger();
-	const result = classify(makeLocal('a.md', 'added'), makeRemote('a.md', 'deleted'), EMPTY_STATE, logger);
+	const result = await classify(makeLocal('a.md', 'added'), makeRemote('a.md', 'deleted'), EMPTY_STATE, logger);
 	expect(result[0]).toMatchObject({ action: 'no-op', local: 'added', remote: 'deleted' });
 	expect(logger.warn).toHaveBeenCalledWith('classifier:impossible-cell', expect.objectContaining({ path: 'a.md' }));
 });
 
 // ─── Row: local=modified ─────────────────────────────────────────────────────
 
-test('(modified, unchanged) — push', () => {
-	const result = classify(makeLocal('a.md', 'modified'), EMPTY_REMOTE, EMPTY_STATE);
+test('(modified, unchanged) — push', async () => {
+	const result = await classify(makeLocal('a.md', 'modified'), EMPTY_REMOTE, EMPTY_STATE);
 	expect(result[0]).toMatchObject({ action: 'push', local: 'modified', remote: 'unchanged' });
 });
 
-test('(modified, added) — impossible: logs warning and returns no-op', () => {
+test('(modified, added) — impossible: logs warning and returns no-op', async () => {
 	const logger = makeLogger();
-	const result = classify(makeLocal('a.md', 'modified'), makeRemote('a.md', 'added'), EMPTY_STATE, logger);
+	const result = await classify(makeLocal('a.md', 'modified'), makeRemote('a.md', 'added'), EMPTY_STATE, logger);
 	expect(result[0]).toMatchObject({ action: 'no-op', local: 'modified', remote: 'added' });
 	expect(logger.warn).toHaveBeenCalledWith('classifier:impossible-cell', expect.objectContaining({ path: 'a.md' }));
 });
 
-test('(modified, modified) — conflict', () => {
-	const result = classify(makeLocal('a.md', 'modified'), makeRemote('a.md', 'modified'), EMPTY_STATE);
+test('(modified, modified) — conflict when no bytes available', async () => {
+	const result = await classify(makeLocal('a.md', 'modified'), makeRemote('a.md', 'modified'), EMPTY_STATE);
 	expect(result[0]).toMatchObject({ action: 'conflict', local: 'modified', remote: 'modified' });
 });
 
-test('(modified, deleted) — conflict', () => {
-	const result = classify(makeLocal('a.md', 'modified'), makeRemote('a.md', 'deleted'), EMPTY_STATE);
+test('(modified, deleted) — conflict', async () => {
+	const result = await classify(makeLocal('a.md', 'modified'), makeRemote('a.md', 'deleted'), EMPTY_STATE);
 	expect(result[0]).toMatchObject({ action: 'conflict', local: 'modified', remote: 'deleted' });
 });
 
 // ─── Row: local=deleted ──────────────────────────────────────────────────────
 
-test('(deleted, unchanged) — push', () => {
-	const result = classify(makeLocal('a.md', 'deleted'), EMPTY_REMOTE, EMPTY_STATE);
+test('(deleted, unchanged) — push', async () => {
+	const result = await classify(makeLocal('a.md', 'deleted'), EMPTY_REMOTE, EMPTY_STATE);
 	expect(result[0]).toMatchObject({ action: 'push', local: 'deleted', remote: 'unchanged' });
 });
 
-test('(deleted, added) — impossible: logs warning and returns no-op', () => {
+test('(deleted, added) — impossible: logs warning and returns no-op', async () => {
 	const logger = makeLogger();
-	const result = classify(makeLocal('a.md', 'deleted'), makeRemote('a.md', 'added'), EMPTY_STATE, logger);
+	const result = await classify(makeLocal('a.md', 'deleted'), makeRemote('a.md', 'added'), EMPTY_STATE, logger);
 	expect(result[0]).toMatchObject({ action: 'no-op', local: 'deleted', remote: 'added' });
 	expect(logger.warn).toHaveBeenCalledWith('classifier:impossible-cell', expect.objectContaining({ path: 'a.md' }));
 });
 
-test('(deleted, modified) — conflict', () => {
-	const result = classify(makeLocal('a.md', 'deleted'), makeRemote('a.md', 'modified'), EMPTY_STATE);
+test('(deleted, modified) — conflict', async () => {
+	const result = await classify(makeLocal('a.md', 'deleted'), makeRemote('a.md', 'modified'), EMPTY_STATE);
 	expect(result[0]).toMatchObject({ action: 'conflict', local: 'deleted', remote: 'modified' });
 });
 
-test('(deleted, deleted) — no-op', () => {
-	const result = classify(makeLocal('a.md', 'deleted'), makeRemote('a.md', 'deleted'), EMPTY_STATE);
+test('(deleted, deleted) — no-op', async () => {
+	const result = await classify(makeLocal('a.md', 'deleted'), makeRemote('a.md', 'deleted'), EMPTY_STATE);
 	expect(result[0]).toMatchObject({ action: 'no-op', local: 'deleted', remote: 'deleted' });
 });
 
 // ─── Multiple paths ───────────────────────────────────────────────────────────
 
-test('multiple paths are each classified independently', () => {
+test('multiple paths are each classified independently', async () => {
 	const localChanges: Map<string, LocalChange> = new Map([
 		['added.md', { path: 'added.md', type: 'added', contentHash: 'h1', size: 5, isBinary: false }],
 		['modified.md', { path: 'modified.md', type: 'modified', contentHash: 'h2', size: 5, isBinary: false }],
@@ -141,7 +149,7 @@ test('multiple paths are each classified independently', () => {
 		['remote-added.md', { path: 'remote-added.md', type: 'added', blobSha: 'b1', size: 5, isBinary: false }],
 	]);
 
-	const result = classify(localChanges, remoteChanges, EMPTY_STATE);
+	const result = await classify(localChanges, remoteChanges, EMPTY_STATE);
 	expect(result).toHaveLength(3);
 
 	const byPath = Object.fromEntries(result.map(r => [r.path, r]));
@@ -150,7 +158,54 @@ test('multiple paths are each classified independently', () => {
 	expect(byPath['remote-added.md'].action).toBe('pull');
 });
 
-test('no logger provided for impossible cell: still returns no-op without throwing', () => {
-	const result = classify(makeLocal('a.md', 'added'), makeRemote('a.md', 'modified'), EMPTY_STATE);
+test('no logger provided for impossible cell: still returns no-op without throwing', async () => {
+	const result = await classify(makeLocal('a.md', 'added'), makeRemote('a.md', 'modified'), EMPTY_STATE);
 	expect(result[0].action).toBe('no-op');
+});
+
+// ─── §4.4 Staleness detection ─────────────────────────────────────────────────
+
+describe('§4.4 staleness', () => {
+	test('(modified, modified) — local bytes match remote blob → state-refresh', async () => {
+		const { bytes, blobSha, contentHash, size } = await makeStalenessFixture();
+		const localChanges = new Map([['a.md', { path: 'a.md', type: 'modified' as const, contentHash, bytes, size, isBinary: false }]]);
+		const remoteChanges = new Map([['a.md', { path: 'a.md', type: 'modified' as const, blobSha, size, isBinary: false }]]);
+
+		const result = await classify(localChanges, remoteChanges, EMPTY_STATE);
+
+		expect(result[0]).toMatchObject({ action: 'state-refresh', local: 'modified', remote: 'modified' });
+	});
+
+	test('(modified, modified) — content differs → conflict (regression)', async () => {
+		const bytes = new TextEncoder().encode('local version').buffer as ArrayBuffer;
+		const contentHash = await sha256(bytes);
+		const localChanges = new Map([['a.md', { path: 'a.md', type: 'modified' as const, contentHash, bytes, size: bytes.byteLength, isBinary: false }]]);
+		const remoteChanges = new Map([['a.md', { path: 'a.md', type: 'modified' as const, blobSha: 'different-blob-sha', size: 12, isBinary: false }]]);
+
+		const result = await classify(localChanges, remoteChanges, EMPTY_STATE);
+
+		expect(result[0]).toMatchObject({ action: 'conflict', local: 'modified', remote: 'modified' });
+	});
+
+	test('(added, added) — local bytes match remote blob → state-refresh', async () => {
+		const { bytes, blobSha, contentHash, size } = await makeStalenessFixture();
+		const localChanges = new Map([['a.md', { path: 'a.md', type: 'added' as const, contentHash, bytes, size, isBinary: false }]]);
+		const remoteChanges = new Map([['a.md', { path: 'a.md', type: 'added' as const, blobSha, size, isBinary: false }]]);
+
+		const result = await classify(localChanges, remoteChanges, EMPTY_STATE);
+
+		expect(result[0]).toMatchObject({ action: 'state-refresh', local: 'added', remote: 'added' });
+	});
+
+	test('(modified, deleted) — no staleness check (remote has no blobSha) → conflict', async () => {
+		const bytes = new TextEncoder().encode('content').buffer as ArrayBuffer;
+		const contentHash = await sha256(bytes);
+		const localChanges = new Map([['a.md', { path: 'a.md', type: 'modified' as const, contentHash, bytes, size: bytes.byteLength, isBinary: false }]]);
+		// remote=deleted: blobSha is undefined
+		const remoteChanges = new Map([['a.md', { path: 'a.md', type: 'deleted' as const, size: 0, isBinary: false }]]);
+
+		const result = await classify(localChanges, remoteChanges, EMPTY_STATE);
+
+		expect(result[0]).toMatchObject({ action: 'conflict', local: 'modified', remote: 'deleted' });
+	});
 });

--- a/tests/classifier.test.ts
+++ b/tests/classifier.test.ts
@@ -71,8 +71,12 @@ test('(added, added) — conflict when no bytes available for staleness check', 
 	expect(result[0]).toMatchObject({ action: 'conflict', local: 'added', remote: 'added' });
 });
 
-test('(added, added) — conflict when bytes present but hashes differ', async () => {
-	const result = await classify(makeLocal('a.md', 'added', 'hash-a'), makeRemote('a.md', 'added', 'hash-b'), EMPTY_STATE);
+test('(added, added) — conflict when bytes present but content differs', async () => {
+	const bytes = new TextEncoder().encode('local content').buffer as ArrayBuffer;
+	const contentHash = await sha256(bytes);
+	const localChanges = new Map([['a.md', { path: 'a.md', type: 'added' as const, contentHash, bytes, size: bytes.byteLength, isBinary: false }]]);
+	const remoteChanges = makeRemote('a.md', 'added', 'different-blob-sha');
+	const result = await classify(localChanges, remoteChanges, EMPTY_STATE);
 	expect(result[0]).toMatchObject({ action: 'conflict' });
 });
 

--- a/tests/sync-engine.test.ts
+++ b/tests/sync-engine.test.ts
@@ -190,7 +190,7 @@ function makeEngine(
 function setupNoChanges() {
 	vi.mocked(buildLocalChangeSet).mockResolvedValue(new Map());
 	vi.mocked(buildRemoteChangeSet).mockResolvedValue(new Map());
-	vi.mocked(classify).mockReturnValue([]);
+	vi.mocked(classify).mockResolvedValue([]);
 }
 
 // ---------------------------------------------------------------------------
@@ -273,7 +273,7 @@ describe('sync lock', () => {
 		const conflictPath = makeClassified('conflict.md', 'conflict', 'modified', 'modified');
 		vi.mocked(buildLocalChangeSet).mockResolvedValue(new Map([['conflict.md', makeLocalChange('conflict.md', 'modified')]]));
 		vi.mocked(buildRemoteChangeSet).mockResolvedValue(new Map([['conflict.md', makeRemoteChange('conflict.md', 'modified')]]));
-		vi.mocked(classify).mockReturnValue([conflictPath]);
+		vi.mocked(classify).mockResolvedValue([conflictPath]);
 		conflicts.resolve.mockResolvedValue('cancel');
 
 		const result1 = await engine.sync();
@@ -307,6 +307,32 @@ describe('normal sync', () => {
 		expect(stateStore.save).toHaveBeenCalled();
 	});
 
+	test('state-refresh paths → state updated, no pull/push, up-to-date', async () => {
+		const state = makeState({ files: {} });
+		const { engine, stateStore } = makeEngine({ stateStore: makeStateStore(state) });
+
+		const stalePath = makeClassified('stale.md', 'state-refresh', 'modified', 'modified');
+		vi.mocked(buildLocalChangeSet).mockResolvedValue(
+			new Map([['stale.md', makeLocalChange('stale.md', 'modified')]]),
+		);
+		vi.mocked(buildRemoteChangeSet).mockResolvedValue(
+			new Map([['stale.md', makeRemoteChange('stale.md', 'modified')]]),
+		);
+		vi.mocked(classify).mockResolvedValue([stalePath]);
+
+		const result = await engine.sync();
+
+		expect(result.status).toBe('up-to-date');
+		expect(applyPull).not.toHaveBeenCalled();
+		expect(applyPush).not.toHaveBeenCalled();
+		// State should have been updated with the refreshed record
+		const savedState = stateStore.save.mock.calls[0]?.[0] as typeof state;
+		expect(savedState.files['stale.md']).toMatchObject({
+			blobSha: 'blob-stale.md',
+			contentHash: 'hash-stale.md',
+		});
+	});
+
 	test('remote-only changes → pull path exercised, state saved, status success', async () => {
 		const state = makeState();
 		const updatedState = makeState({ lastSyncCommitSha: 'remote-head' });
@@ -317,7 +343,7 @@ describe('normal sync', () => {
 		vi.mocked(buildRemoteChangeSet).mockResolvedValue(
 			new Map([['remote-note.md', makeRemoteChange('remote-note.md', 'added')]]),
 		);
-		vi.mocked(classify).mockReturnValue([remotePath]);
+		vi.mocked(classify).mockResolvedValue([remotePath]);
 		vi.mocked(applyPull).mockResolvedValue({ updatedState, skipped: [] });
 
 		const result = await engine.sync();
@@ -343,7 +369,7 @@ describe('normal sync', () => {
 			new Map([['local-note.md', makeLocalChange('local-note.md', 'added')]]),
 		);
 		vi.mocked(buildRemoteChangeSet).mockResolvedValue(new Map());
-		vi.mocked(classify).mockReturnValue([localPath]);
+		vi.mocked(classify).mockResolvedValue([localPath]);
 		vi.mocked(applyPush).mockResolvedValue({ newCommitSha: 'new-commit-sha', updatedState });
 
 		const result = await engine.sync();
@@ -367,7 +393,7 @@ describe('normal sync', () => {
 			new Map([['gone.md', makeLocalChange('gone.md', 'deleted')]]),
 		);
 		vi.mocked(buildRemoteChangeSet).mockResolvedValue(new Map());
-		vi.mocked(classify).mockReturnValue([localPath]);
+		vi.mocked(classify).mockResolvedValue([localPath]);
 		vi.mocked(applyPush).mockResolvedValue({ newCommitSha: 'new-commit', updatedState });
 
 		const result = await engine.sync();
@@ -394,7 +420,7 @@ describe('normal sync', () => {
 		vi.mocked(buildRemoteChangeSet).mockResolvedValue(
 			new Map([['conflict.md', makeRemoteChange('conflict.md', 'modified')]]),
 		);
-		vi.mocked(classify).mockReturnValue([conflictPath]);
+		vi.mocked(classify).mockResolvedValue([conflictPath]);
 		vi.mocked(applyPush).mockResolvedValue({ newCommitSha: 'new-commit', updatedState });
 
 		const result = await engine.sync();
@@ -422,7 +448,7 @@ describe('normal sync', () => {
 		vi.mocked(buildRemoteChangeSet).mockResolvedValue(
 			new Map([['conflict.md', makeRemoteChange('conflict.md', 'modified')]]),
 		);
-		vi.mocked(classify).mockReturnValue([conflictPath]);
+		vi.mocked(classify).mockResolvedValue([conflictPath]);
 		vi.mocked(applyPull).mockResolvedValue({ updatedState, skipped: [] });
 
 		const result = await engine.sync();
@@ -443,7 +469,7 @@ describe('normal sync', () => {
 		const conflictPath = makeClassified('conflict.md', 'conflict', 'modified', 'modified');
 		vi.mocked(buildLocalChangeSet).mockResolvedValue(new Map());
 		vi.mocked(buildRemoteChangeSet).mockResolvedValue(new Map());
-		vi.mocked(classify).mockReturnValue([conflictPath]);
+		vi.mocked(classify).mockResolvedValue([conflictPath]);
 		conflicts.resolve.mockResolvedValue('cancel');
 
 		const result = await engine.sync();
@@ -467,7 +493,7 @@ describe('normal sync', () => {
 		vi.mocked(buildRemoteChangeSet).mockResolvedValue(
 			new Map([['conflict.md', makeRemoteChange('conflict.md', 'modified')]]),
 		);
-		vi.mocked(classify).mockReturnValue([conflictPath]);
+		vi.mocked(classify).mockResolvedValue([conflictPath]);
 		conflicts.resolve.mockResolvedValue(new Map([['conflict.md', 'keep-local']]));
 		vi.mocked(applyPush).mockResolvedValue({ newCommitSha: 'new-commit', updatedState });
 
@@ -488,7 +514,7 @@ describe('normal sync', () => {
 		vi.mocked(buildRemoteChangeSet).mockResolvedValue(
 			new Map([['large.zip', makeRemoteChange('large.zip', 'added')]]),
 		);
-		vi.mocked(classify).mockReturnValue([pullPath]);
+		vi.mocked(classify).mockResolvedValue([pullPath]);
 		vi.mocked(applyPull).mockResolvedValue({ updatedState, skipped: ['large.zip'] });
 
 		const result = await engine.sync();
@@ -515,7 +541,7 @@ describe('GHFastForwardError retry', () => {
 			new Map([['note.md', makeLocalChange('note.md', 'modified')]]),
 		);
 		vi.mocked(buildRemoteChangeSet).mockResolvedValue(new Map());
-		vi.mocked(classify).mockReturnValue([pushPath]);
+		vi.mocked(classify).mockResolvedValue([pushPath]);
 		vi.mocked(applyPull).mockResolvedValue({ updatedState: state, skipped: [] });
 		vi.mocked(applyPush)
 			.mockRejectedValueOnce(new GHFastForwardError('ff required'))
@@ -538,7 +564,7 @@ describe('GHFastForwardError retry', () => {
 			new Map([['note.md', makeLocalChange('note.md', 'modified')]]),
 		);
 		vi.mocked(buildRemoteChangeSet).mockResolvedValue(new Map());
-		vi.mocked(classify).mockReturnValue([pushPath]);
+		vi.mocked(classify).mockResolvedValue([pushPath]);
 		vi.mocked(applyPush)
 			.mockRejectedValueOnce(new GHFastForwardError('ff'))
 			.mockRejectedValueOnce(new GHFastForwardError('ff'))
@@ -560,7 +586,7 @@ describe('GHFastForwardError retry', () => {
 			new Map([['note.md', makeLocalChange('note.md', 'modified')]]),
 		);
 		vi.mocked(buildRemoteChangeSet).mockResolvedValue(new Map());
-		vi.mocked(classify).mockReturnValue([pushPath]);
+		vi.mocked(classify).mockResolvedValue([pushPath]);
 		vi.mocked(applyPush).mockRejectedValue(new GHFastForwardError('ff'));
 
 		const result = await engine.sync();
@@ -584,7 +610,7 @@ describe('GHFastForwardError retry', () => {
 		vi.mocked(buildRemoteChangeSet).mockResolvedValue(
 			new Map([['conflict.md', makeRemoteChange('conflict.md', 'modified')]]),
 		);
-		vi.mocked(classify).mockReturnValue([conflictPath]);
+		vi.mocked(classify).mockResolvedValue([conflictPath]);
 		vi.mocked(applyPush)
 			.mockRejectedValueOnce(new GHFastForwardError('ff'))
 			.mockResolvedValue({ newCommitSha: 'new-commit', updatedState });
@@ -791,7 +817,7 @@ describe('logging', () => {
 			new Map([['note.md', makeLocalChange('note.md', 'added')]]),
 		);
 		vi.mocked(buildRemoteChangeSet).mockResolvedValue(new Map());
-		vi.mocked(classify).mockReturnValue([pushPath]);
+		vi.mocked(classify).mockResolvedValue([pushPath]);
 		vi.mocked(applyPush).mockResolvedValue({ newCommitSha: 'new-commit', updatedState });
 
 		await engine.sync();
@@ -812,7 +838,7 @@ describe('logging', () => {
 			new Map([['note.md', makeLocalChange('note.md', 'added')]]),
 		);
 		vi.mocked(buildRemoteChangeSet).mockResolvedValue(new Map());
-		vi.mocked(classify).mockReturnValue([pushPath]);
+		vi.mocked(classify).mockResolvedValue([pushPath]);
 		vi.mocked(applyPush).mockResolvedValue({ newCommitSha: 'new-commit', updatedState });
 
 		await engine.sync();


### PR DESCRIPTION
When two devices share Obsidian Sync, device B may see a stale
sync-state.json and classify a path as a conflict even though the local
bytes already match the remote blob (device A pushed them). Detect this
by computing gitBlobSha1(localBytes) and comparing to remoteChange.blobSha
inside classify(); emit 'state-refresh' instead of 'conflict', and update
state.files[path] in the engine without any vault or network I/O.

Closes #66

https://claude.ai/code/session_01CZ3HMsBNCV7THcDTGZoEQL