### PR TITLE
Add Diagnostics section to settings tab (issue #67)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,9 +3,11 @@ import { Settings, DEFAULT_SETTINGS } from './settings';
 import { JackdawSettingsTab } from './ui/settings-tab';
 import { RibbonIcon } from './ui/ribbon';
 import { StatusBar } from './ui/status-bar';
+import { GitHubClient } from './github-client';
 
 export default class JackdawPlugin extends Plugin {
 	settings!: Settings;
+	client!: GitHubClient;
 
 	async onload(): Promise<void> {
 		if (Platform.isAndroidApp) {
@@ -15,7 +17,14 @@ export default class JackdawPlugin extends Plugin {
 
 		await this.loadSettings();
 
-		this.addSettingTab(new JackdawSettingsTab(this.app, this));
+		this.client = new GitHubClient(
+			() => this.settings.pat,
+			() => this.settings.owner,
+			() => this.settings.repo,
+			this.manifest.version,
+		);
+
+		this.addSettingTab(new JackdawSettingsTab(this.app, this, this.client));
 
 		let statusBar: StatusBar | undefined;
 		if (!Platform.isMobileApp) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { GitHubClient } from './github-client';
 
 export default class JackdawPlugin extends Plugin {
 	settings!: Settings;
-	client!: GitHubClient;
+	private client!: GitHubClient;
 
 	async onload(): Promise<void> {
 		if (Platform.isAndroidApp) {

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1,13 +1,17 @@
-import { App, PluginSettingTab, Setting } from 'obsidian';
+import { App, Modal, Notice, PluginSettingTab, Setting } from 'obsidian';
 import { DEFAULT_SETTINGS } from '../settings';
+import { GitHubClient, GHAuthError, GHNotFoundError } from '../github-client';
+import { PLUGIN_ID } from '../constants';
 import type JackdawPlugin from '../main';
 
 export class JackdawSettingsTab extends PluginSettingTab {
 	plugin: JackdawPlugin;
+	private client: GitHubClient;
 
-	constructor(app: App, plugin: JackdawPlugin) {
+	constructor(app: App, plugin: JackdawPlugin, client: GitHubClient) {
 		super(app, plugin);
 		this.plugin = plugin;
+		this.client = client;
 	}
 
 	display(): void {
@@ -162,5 +166,117 @@ export class JackdawSettingsTab extends PluginSettingTab {
 				area.inputEl.rows = 6;
 				area.inputEl.style.width = '100%';
 			});
+
+		// Diagnostics
+		containerEl.createEl('h2', { text: 'Diagnostics' });
+
+		new Setting(containerEl)
+			.addButton(btn =>
+				btn.setButtonText('Test connection').onClick(async () => {
+					btn.setButtonText('Testing…');
+					btn.setDisabled(true);
+					try {
+						const { owner, repo, branch } = this.plugin.settings;
+						const result = await this.client.getBranch(owner, repo, branch);
+						new Notice(`Connection OK — branch HEAD: ${result.commitSha.slice(0, 7)}`);
+					} catch (err) {
+						if (err instanceof GHAuthError) {
+							new Notice('Authentication failed — check your PAT');
+						} else if (err instanceof GHNotFoundError) {
+							new Notice('Repo or branch not found, or PAT lacks access');
+						} else {
+							new Notice(`Connection failed: ${err instanceof Error ? err.message : String(err)}`);
+						}
+					} finally {
+						btn.setButtonText('Test connection');
+						btn.setDisabled(false);
+					}
+				})
+			);
+
+		new Setting(containerEl)
+			.addButton(btn =>
+				btn.setButtonText('View log').onClick(async () => {
+					const logPath = `.obsidian/plugins/${PLUGIN_ID}/sync.log`;
+					let contents: string;
+					const exists = await this.app.vault.adapter.exists(logPath);
+					if (exists) {
+						contents = await this.app.vault.adapter.read(logPath);
+					} else {
+						contents = '(No log entries yet.)';
+					}
+					new SyncLogModal(this.app, contents).open();
+				})
+			);
+
+		new Setting(containerEl)
+			.setName('Reset sync state')
+			.setDesc('Deletes the local sync state. The next sync will be treated as a first-sync.')
+			.addButton(btn =>
+				btn.setButtonText('Reset sync state').onClick(() => {
+					new ResetSyncStateModal(this.app).open();
+				})
+			);
+
+		new Setting(containerEl)
+			.setName('Verbose logging')
+			.setDesc('Logs per-file pull and push events to the sync log. Use only when debugging.')
+			.addToggle(toggle =>
+				toggle
+					.setValue(this.plugin.settings.verboseLogging)
+					.onChange(async value => {
+						this.plugin.settings.verboseLogging = value;
+						await this.plugin.saveSettings();
+					})
+			);
+	}
+}
+
+class SyncLogModal extends Modal {
+	private contents: string;
+
+	constructor(app: App, contents: string) {
+		super(app);
+		this.contents = contents;
+	}
+
+	onOpen(): void {
+		this.titleEl.setText('Sync log');
+		this.contentEl.createEl('pre', { text: this.contents });
+		new Setting(this.contentEl)
+			.addButton(btn => btn.setButtonText('Close').onClick(() => this.close()));
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+}
+
+class ResetSyncStateModal extends Modal {
+	onOpen(): void {
+		this.titleEl.setText('Reset sync state?');
+		this.contentEl.createEl('p', {
+			text: `This deletes .obsidian/plugins/${PLUGIN_ID}/sync-state.json. The next sync will scan the entire vault and the entire repository, and may prompt you to resolve conflicts. This does not delete any notes or any commits on GitHub.`,
+		});
+		new Setting(this.contentEl)
+			.addButton(btn => btn.setButtonText('Cancel').onClick(() => this.close()))
+			.addButton(btn =>
+				btn
+					.setButtonText('Reset')
+					.setWarning()
+					.onClick(async () => {
+						const statePath = `.obsidian/plugins/${PLUGIN_ID}/sync-state.json`;
+						const exists = await this.app.vault.adapter.exists(statePath);
+						if (exists) {
+							await this.app.vault.adapter.remove(statePath);
+						}
+						this.close();
+						new Notice('Sync state reset.');
+					})
+			);
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
 	}
 }

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -199,11 +199,14 @@ export class JackdawSettingsTab extends PluginSettingTab {
 				btn.setButtonText('View log').onClick(async () => {
 					const logPath = `.obsidian/plugins/${PLUGIN_ID}/sync.log`;
 					let contents: string;
-					const exists = await this.app.vault.adapter.exists(logPath);
-					if (exists) {
-						contents = await this.app.vault.adapter.read(logPath);
-					} else {
-						contents = '(No log entries yet.)';
+					try {
+						const exists = await this.app.vault.adapter.exists(logPath);
+						contents = exists
+							? await this.app.vault.adapter.read(logPath)
+							: '(No log entries yet.)';
+					} catch (err) {
+						new Notice(`Failed to read log: ${err instanceof Error ? err.message : String(err)}`);
+						return;
 					}
 					new SyncLogModal(this.app, contents).open();
 				})
@@ -266,9 +269,14 @@ class ResetSyncStateModal extends Modal {
 					.setWarning()
 					.onClick(async () => {
 						const statePath = `.obsidian/plugins/${PLUGIN_ID}/sync-state.json`;
-						const exists = await this.app.vault.adapter.exists(statePath);
-						if (exists) {
-							await this.app.vault.adapter.remove(statePath);
+						try {
+							const exists = await this.app.vault.adapter.exists(statePath);
+							if (exists) {
+								await this.app.vault.adapter.remove(statePath);
+							}
+						} catch (err) {
+							new Notice(`Failed to reset sync state: ${err instanceof Error ? err.message : String(err)}`);
+							return;
 						}
 						this.close();
 						new Notice('Sync state reset.');


### PR DESCRIPTION
Implements the four diagnostic UI elements: Test connection button
(calls getBranch with live settings and toasts the result), View log
button (opens a read-only modal with sync.log contents), Reset sync
state button (opens a confirmation modal before removing sync-state.json),
and Verbose logging toggle (persists via saveSettings).

GitHubClient is now owned by main.ts and injected into JackdawSettingsTab
via constructor.

https://claude.ai/code/session_017oeDYcLEukxfKm2WPuV7hT