### PR TITLE
Wire main.ts to sync engine with notices and status updates

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -16,12 +16,12 @@ export class Logger {
 	constructor(
 		adapter: DataAdapter,
 		prefix: string,
-		verbose: boolean | (() => boolean),
+		getVerbose: () => boolean,
 		getPat: () => string,
 	) {
 		this.adapter = adapter;
 		this.prefix = prefix;
-		this.getVerbose = typeof verbose === 'function' ? verbose : () => verbose;
+		this.getVerbose = getVerbose;
 		this.getPat = getPat;
 	}
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -10,19 +10,24 @@ const MAX_BYTES = 1024 * 1024; // 1 MB
 export class Logger {
 	private adapter: DataAdapter;
 	private prefix: string;
-	private verbose: boolean;
+	private getVerbose: () => boolean;
 	private getPat: () => string;
 
-	constructor(adapter: DataAdapter, prefix: string, verbose: boolean, getPat: () => string) {
+	constructor(
+		adapter: DataAdapter,
+		prefix: string,
+		verbose: boolean | (() => boolean),
+		getPat: () => string,
+	) {
 		this.adapter = adapter;
 		this.prefix = prefix;
-		this.verbose = verbose;
+		this.getVerbose = typeof verbose === 'function' ? verbose : () => verbose;
 		this.getPat = getPat;
 	}
 
 	// Never log file contents.
 	debug(event: string, fields?: Fields): Promise<void> {
-		if (!this.verbose) return Promise.resolve();
+		if (!this.getVerbose()) return Promise.resolve();
 		return this.emit('debug', event, fields);
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ export default class JackdawPlugin extends Plugin {
 	private ribbon?: RibbonIcon;
 	private statusBar?: StatusBar;
 	private lastSyncAt: string | null = null;
+	private isRunningSync = false;
 
 	async onload(): Promise<void> {
 		await this.loadSettings();
@@ -95,6 +96,11 @@ export default class JackdawPlugin extends Plugin {
 
 	async runSync(): Promise<void> {
 		if (!this.engine) return;
+		// Guard at the UI layer: without this, a second click while a sync is in
+		// flight would flip the spinner off in its own finally block — even though
+		// the first sync is still running.
+		if (this.isRunningSync) return;
+		this.isRunningSync = true;
 		this.statusBar?.setSyncing();
 		this.ribbon?.setSyncing();
 		try {
@@ -102,6 +108,7 @@ export default class JackdawPlugin extends Plugin {
 			this.handleSyncResult(result);
 		} finally {
 			this.ribbon?.setIdle();
+			this.isRunningSync = false;
 		}
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,58 +1,136 @@
-import { Notice, Platform, Plugin } from 'obsidian';
+import { App, Notice, Platform, Plugin, PluginSettingTab } from 'obsidian';
 import { Settings, DEFAULT_SETTINGS } from './settings';
 import { JackdawSettingsTab } from './ui/settings-tab';
 import { RibbonIcon } from './ui/ribbon';
 import { StatusBar } from './ui/status-bar';
 import { GitHubClient } from './github-client';
+import { Logger } from './logger';
+import { ObsidianStateAdapter } from './obsidian-state-adapter';
+import { StateStore } from './state-store';
+import { ObsidianVaultAdapter } from './obsidian-vault-adapter';
+import { SyncEngine } from './sync-engine';
+import { PolicyBasedResolver } from './sync-engine-types';
+import type { SyncResult } from './sync-engine-types';
+import { formatSyncOutcome } from './sync-notice';
 
 export default class JackdawPlugin extends Plugin {
 	settings!: Settings;
-	private client!: GitHubClient;
+	private engine?: SyncEngine;
+	private ribbon?: RibbonIcon;
+	private statusBar?: StatusBar;
+	private lastSyncAt: string | null = null;
 
 	async onload(): Promise<void> {
+		await this.loadSettings();
+
 		if (Platform.isAndroidApp) {
-			new Notice('Jackdaw: This plugin is not supported on Android. iOS and desktop only.');
+			this.addSettingTab(new AndroidUnsupportedSettingsTab(this.app, this));
 			return;
 		}
 
-		await this.loadSettings();
+		const pluginFolder = `${this.app.vault.configDir}/plugins/${this.manifest.id}`;
 
-		this.client = new GitHubClient(
+		const logger = new Logger(
+			this.app.vault.adapter,
+			pluginFolder,
+			() => this.settings.verboseLogging,
+			() => this.settings.pat,
+		);
+
+		const stateStore = new StateStore(
+			new ObsidianStateAdapter(this.app.vault.adapter),
+			pluginFolder,
+			logger,
+		);
+
+		const vault = new ObsidianVaultAdapter(this.app);
+
+		const client = new GitHubClient(
 			() => this.settings.pat,
 			() => this.settings.owner,
 			() => this.settings.repo,
 			this.manifest.version,
+			logger,
 		);
 
-		this.addSettingTab(new JackdawSettingsTab(this.app, this, this.client));
+		const resolver = new PolicyBasedResolver(this.settings.conflictPolicy);
 
-		let statusBar: StatusBar | undefined;
+		this.engine = new SyncEngine(
+			vault,
+			client,
+			stateStore,
+			logger,
+			() => this.settings,
+			resolver,
+			resolver,
+		);
+
 		if (!Platform.isMobileApp) {
-			statusBar = new StatusBar(this.addStatusBarItem());
+			this.statusBar = new StatusBar(this.addStatusBarItem());
+			try {
+				const initial = await stateStore.load();
+				if (initial) {
+					this.lastSyncAt = initial.lastSyncAt;
+					this.statusBar.setIdle(initial.lastSyncAt);
+				}
+			} catch {
+				// Seeding the status bar is best-effort; sync itself will surface real errors.
+			}
 		}
 
-		const syncAction = async (): Promise<void> => {
-			ribbon.setSyncing();
-			statusBar?.setSyncing();
-			try {
-				// TODO: wire sync engine
-				new Notice('Jackdaw: Sync coming soon');
-			} finally {
-				ribbon.setIdle();
-				statusBar?.setIdle(null);
-			}
+		this.addSettingTab(new JackdawSettingsTab(this.app, this, client));
+
+		const trigger = (): void => {
+			void this.runSync();
 		};
 
-		const ribbon = new RibbonIcon(this, syncAction);
+		this.ribbon = new RibbonIcon(this, trigger);
 
 		this.addCommand({
 			id: 'sync-vault',
 			name: 'Sync with GitHub',
-			callback: syncAction,
+			callback: trigger,
 		});
 	}
 
-	onunload(): void {}
+	async runSync(): Promise<void> {
+		if (!this.engine) return;
+		this.statusBar?.setSyncing();
+		this.ribbon?.setSyncing();
+		try {
+			const result = await this.engine.sync();
+			this.handleSyncResult(result);
+		} finally {
+			this.ribbon?.setIdle();
+		}
+	}
+
+	private handleSyncResult(result: SyncResult): void {
+		const outcome = formatSyncOutcome(
+			result,
+			() => new Date().toISOString(),
+			this.lastSyncAt,
+		);
+
+		for (const toast of outcome.toasts) {
+			new Notice(toast);
+		}
+
+		if (outcome.statusBar.kind === 'idle') {
+			if (outcome.statusBar.lastSyncAt !== null) {
+				this.lastSyncAt = outcome.statusBar.lastSyncAt;
+			}
+			this.statusBar?.setIdle(outcome.statusBar.lastSyncAt);
+		} else {
+			this.statusBar?.setError(outcome.statusBar.message);
+		}
+	}
+
+	onunload(): void {
+		this.statusBar = undefined;
+		this.ribbon = undefined;
+		this.engine = undefined;
+	}
 
 	async loadSettings(): Promise<void> {
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
@@ -60,5 +138,20 @@ export default class JackdawPlugin extends Plugin {
 
 	async saveSettings(): Promise<void> {
 		await this.saveData(this.settings);
+	}
+}
+
+class AndroidUnsupportedSettingsTab extends PluginSettingTab {
+	constructor(app: App, plugin: JackdawPlugin) {
+		super(app, plugin);
+	}
+
+	display(): void {
+		const { containerEl } = this;
+		containerEl.empty();
+		containerEl.createEl('h2', { text: 'Jackdaw' });
+		containerEl.createEl('p', {
+			text: 'Jackdaw is not supported on Android. The plugin works on Obsidian desktop and iOS only.',
+		});
 	}
 }

--- a/src/sync-notice.ts
+++ b/src/sync-notice.ts
@@ -1,0 +1,59 @@
+import type { SyncResult } from './sync-engine-types';
+
+export type StatusBarUpdate =
+	| { kind: 'idle'; lastSyncAt: string | null }
+	| { kind: 'error'; message: string };
+
+export interface SyncNoticeOutcome {
+	toasts: string[];
+	statusBar: StatusBarUpdate;
+}
+
+const SYNC_NEEDS_UI_MESSAGE =
+	"Conflict resolution UI is not yet available. Choose 'Prefer local' or 'Prefer remote' in settings, or wait for the next release.";
+const SYNC_NEEDS_UI_STATUS = 'Conflict — set conflict policy';
+
+export function formatSyncOutcome(
+	result: SyncResult,
+	now: () => string,
+	lastKnownSyncAt: string | null,
+): SyncNoticeOutcome {
+	switch (result.status) {
+		case 'up-to-date':
+			return {
+				toasts: ['Already up to date.'],
+				statusBar: { kind: 'idle', lastSyncAt: now() },
+			};
+		case 'success': {
+			const { filesAdded, filesModified, filesDeleted, skippedOversized } = result.report;
+			const total = filesAdded + filesModified + filesDeleted;
+			const toasts = [`Synced ${total} change${total === 1 ? '' : 's'}.`];
+			if (skippedOversized.length > 0) {
+				const first3 = skippedOversized.slice(0, 3).join(', ');
+				const rest = skippedOversized.length - 3;
+				const suffix = rest > 0 ? ` and ${rest} more` : '';
+				toasts.push(`Skipped: ${first3}${suffix}`);
+			}
+			return {
+				toasts,
+				statusBar: { kind: 'idle', lastSyncAt: now() },
+			};
+		}
+		case 'cancelled':
+			return {
+				toasts: [],
+				statusBar: { kind: 'idle', lastSyncAt: lastKnownSyncAt },
+			};
+		case 'error':
+			if (result.error.name === 'SyncNeedsUIError') {
+				return {
+					toasts: [SYNC_NEEDS_UI_MESSAGE],
+					statusBar: { kind: 'error', message: SYNC_NEEDS_UI_STATUS },
+				};
+			}
+			return {
+				toasts: [`Sync failed: ${result.error.message}. See log for details.`],
+				statusBar: { kind: 'error', message: result.error.message },
+			};
+	}
+}

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -36,7 +36,7 @@ describe('Logger', () => {
 	});
 
 	test('emits one JSON line per write in JSONL format', async () => {
-		const logger = new Logger(adapter as never, PREFIX, true, () => '');
+		const logger = new Logger(adapter as never, PREFIX, () => true, () => '');
 		await logger.info('sync.start');
 		await logger.info('sync.complete', { duration: 100 });
 
@@ -56,7 +56,7 @@ describe('Logger', () => {
 	});
 
 	test('spreads fields into the top-level JSON object', async () => {
-		const logger = new Logger(adapter as never, PREFIX, true, () => '');
+		const logger = new Logger(adapter as never, PREFIX, () => true, () => '');
 		await logger.warn('sync.conflicts', { count: 3, paths: ['a.md', 'b.md'] });
 
 		const line = adapter.store[LOG_PATH].trim();
@@ -69,7 +69,7 @@ describe('Logger', () => {
 		const priorContent = 'x'.repeat(MAX_BYTES);
 		adapter = makeAdapter({ [LOG_PATH]: priorContent });
 
-		const logger = new Logger(adapter as never, PREFIX, true, () => '');
+		const logger = new Logger(adapter as never, PREFIX, () => true, () => '');
 		await logger.info('sync.start');
 
 		expect(adapter.store[BACKUP_PATH]).toBe(priorContent);
@@ -85,7 +85,7 @@ describe('Logger', () => {
 		const oldBackup = 'old backup content';
 		adapter = makeAdapter({ [LOG_PATH]: priorContent, [BACKUP_PATH]: oldBackup });
 
-		const logger = new Logger(adapter as never, PREFIX, true, () => '');
+		const logger = new Logger(adapter as never, PREFIX, () => true, () => '');
 		await logger.info('sync.start');
 
 		expect(adapter.store[BACKUP_PATH]).toBe(priorContent);
@@ -96,7 +96,7 @@ describe('Logger', () => {
 		const smallContent = '{"ts":"2026-01-01","level":"info","event":"sync.start"}\n';
 		adapter = makeAdapter({ [LOG_PATH]: smallContent });
 
-		const logger = new Logger(adapter as never, PREFIX, true, () => '');
+		const logger = new Logger(adapter as never, PREFIX, () => true, () => '');
 		await logger.info('sync.complete');
 
 		expect(adapter.rename).not.toHaveBeenCalled();
@@ -106,7 +106,7 @@ describe('Logger', () => {
 
 	test('scrubs PAT from field values', async () => {
 		const pat = 'ghp_supersecrettoken';
-		const logger = new Logger(adapter as never, PREFIX, true, () => pat);
+		const logger = new Logger(adapter as never, PREFIX, () => true, () => pat);
 		await logger.info('sync.error', { message: `failed with token ${pat}` });
 
 		const line = adapter.store[LOG_PATH].trim();
@@ -116,7 +116,7 @@ describe('Logger', () => {
 
 	test('scrubs Authorization Bearer value', async () => {
 		const pat = 'ghp_mytoken';
-		const logger = new Logger(adapter as never, PREFIX, true, () => pat);
+		const logger = new Logger(adapter as never, PREFIX, () => true, () => pat);
 		await logger.info('api.call', { header: 'Authorization: Bearer ghp_mytoken' });
 
 		const line = adapter.store[LOG_PATH].trim();
@@ -125,7 +125,7 @@ describe('Logger', () => {
 	});
 
 	test('scrubs Authorization header even when PAT is unknown', async () => {
-		const logger = new Logger(adapter as never, PREFIX, true, () => '');
+		const logger = new Logger(adapter as never, PREFIX, () => true, () => '');
 		await logger.info('api.call', { header: 'Authorization: Bearer someOtherToken' });
 
 		const line = adapter.store[LOG_PATH].trim();
@@ -134,7 +134,7 @@ describe('Logger', () => {
 	});
 
 	test('debug is silent when verbose logging is off', async () => {
-		const logger = new Logger(adapter as never, PREFIX, false, () => '');
+		const logger = new Logger(adapter as never, PREFIX, () => false, () => '');
 		await logger.debug('sync.pull.file', { path: 'notes/a.md' });
 
 		expect(adapter.append).not.toHaveBeenCalled();
@@ -142,7 +142,7 @@ describe('Logger', () => {
 	});
 
 	test('debug emits when verbose logging is on', async () => {
-		const logger = new Logger(adapter as never, PREFIX, true, () => '');
+		const logger = new Logger(adapter as never, PREFIX, () => true, () => '');
 		await logger.debug('sync.pull.file', { path: 'notes/a.md' });
 
 		const line = adapter.store[LOG_PATH].trim();
@@ -153,7 +153,7 @@ describe('Logger', () => {
 	});
 
 	test('warn and error always emit regardless of verbose flag', async () => {
-		const logger = new Logger(adapter as never, PREFIX, false, () => '');
+		const logger = new Logger(adapter as never, PREFIX, () => false, () => '');
 		await logger.warn('sync.conflicts', { count: 1 });
 		await logger.error('sync.error', { message: 'boom' });
 

--- a/tests/sync-notice.test.ts
+++ b/tests/sync-notice.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'vitest';
+import { formatSyncOutcome } from '../src/sync-notice';
+import { SyncNeedsUIError } from '../src/sync-engine-types';
+import type { SyncReport, SyncResult } from '../src/sync-engine-types';
+
+const NOW = '2026-04-30T12:00:00.000Z';
+const now = (): string => NOW;
+
+function emptyReport(overrides: Partial<SyncReport> = {}): SyncReport {
+	return {
+		filesAdded: 0,
+		filesModified: 0,
+		filesDeleted: 0,
+		conflictsResolved: 0,
+		skippedOversized: [],
+		commitSha: null,
+		durationMs: 0,
+		...overrides,
+	};
+}
+
+describe('formatSyncOutcome', () => {
+	test('up-to-date emits the up-to-date toast and idle status with current time', () => {
+		const result: SyncResult = { status: 'up-to-date', report: emptyReport() };
+		const outcome = formatSyncOutcome(result, now, null);
+
+		expect(outcome.toasts).toEqual(['Already up to date.']);
+		expect(outcome.statusBar).toEqual({ kind: 'idle', lastSyncAt: NOW });
+	});
+
+	test('success summarizes total changes', () => {
+		const result: SyncResult = {
+			status: 'success',
+			report: emptyReport({ filesAdded: 2, filesModified: 1, filesDeleted: 1, commitSha: 'abc' }),
+		};
+		const outcome = formatSyncOutcome(result, now, null);
+
+		expect(outcome.toasts).toEqual(['Synced 4 changes.']);
+		expect(outcome.statusBar).toEqual({ kind: 'idle', lastSyncAt: NOW });
+	});
+
+	test('success with one change uses singular wording', () => {
+		const result: SyncResult = {
+			status: 'success',
+			report: emptyReport({ filesAdded: 1, commitSha: 'abc' }),
+		};
+		const outcome = formatSyncOutcome(result, now, null);
+
+		expect(outcome.toasts).toEqual(['Synced 1 change.']);
+	});
+
+	test('success with skipped-oversized lists first 3 with "and N more" suffix', () => {
+		const result: SyncResult = {
+			status: 'success',
+			report: emptyReport({
+				filesAdded: 1,
+				skippedOversized: ['big1.bin', 'big2.bin', 'big3.bin', 'big4.bin', 'big5.bin'],
+			}),
+		};
+		const outcome = formatSyncOutcome(result, now, null);
+
+		expect(outcome.toasts).toEqual([
+			'Synced 1 change.',
+			'Skipped: big1.bin, big2.bin, big3.bin and 2 more',
+		]);
+	});
+
+	test('success with skipped-oversized of length 3 omits the "and N more" suffix', () => {
+		const result: SyncResult = {
+			status: 'success',
+			report: emptyReport({ filesAdded: 0, skippedOversized: ['a', 'b', 'c'] }),
+		};
+		const outcome = formatSyncOutcome(result, now, null);
+
+		expect(outcome.toasts).toEqual([
+			'Synced 0 changes.',
+			'Skipped: a, b, c',
+		]);
+	});
+
+	test('cancelled emits no toast and reverts status bar to last known sync time', () => {
+		const lastKnown = '2026-04-30T11:00:00.000Z';
+		const result: SyncResult = { status: 'cancelled' };
+		const outcome = formatSyncOutcome(result, now, lastKnown);
+
+		expect(outcome.toasts).toEqual([]);
+		expect(outcome.statusBar).toEqual({ kind: 'idle', lastSyncAt: lastKnown });
+	});
+
+	test('cancelled with no last known sync time leaves status bar in never-synced state', () => {
+		const outcome = formatSyncOutcome({ status: 'cancelled' }, now, null);
+		expect(outcome.statusBar).toEqual({ kind: 'idle', lastSyncAt: null });
+	});
+
+	test('SyncNeedsUIError produces dedicated message and dedicated status bar text', () => {
+		const result: SyncResult = { status: 'error', error: new SyncNeedsUIError() };
+		const outcome = formatSyncOutcome(result, now, null);
+
+		expect(outcome.toasts).toEqual([
+			"Conflict resolution UI is not yet available. Choose 'Prefer local' or 'Prefer remote' in settings, or wait for the next release.",
+		]);
+		expect(outcome.statusBar).toEqual({
+			kind: 'error',
+			message: 'Conflict — set conflict policy',
+		});
+	});
+
+	test('generic error includes the error message and points to the log', () => {
+		const result: SyncResult = {
+			status: 'error',
+			error: new Error('Network unreachable'),
+		};
+		const outcome = formatSyncOutcome(result, now, null);
+
+		expect(outcome.toasts).toEqual([
+			'Sync failed: Network unreachable. See log for details.',
+		]);
+		expect(outcome.statusBar).toEqual({
+			kind: 'error',
+			message: 'Network unreachable',
+		});
+	});
+});


### PR DESCRIPTION
Replaces the main.ts stub with the production plugin entry point. Instantiates
Logger, StateStore, VaultAdapter, GitHubClient, PolicyBasedResolver, and
SyncEngine; registers ribbon, command, status bar (desktop only), and settings
tab; handles each sync result with the toast and status-bar updates from §8.5.

Logger gains a getter form for the verbose flag so settings toggles take effect
on the next sync without a plugin reload.

The sync result → toast/status mapping is extracted into a pure
formatSyncOutcome helper so every status (up-to-date, success with
skipped-oversized, cancelled, SyncNeedsUIError, generic error) is unit-tested.

Android short-circuits to a settings-only tab with the unsupported notice.

(Closes #68)