### PR TITLE
Remove references to human-interactions.md; add testing.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ The full design specification is at `docs/design-specification.md` and is the au
 
 ## Project status
 
-Phase 0 (scaffold) is complete. Phase 1 (core libs) is complete. Phase 2 (sync engine) is next.
+Phase 0 (scaffold) is complete. Phase 1 (core libs) is complete. Phase 2 (sync engine) is complete. Phase 3 (UI) is complete. Phase 4 (first-sync + conflicts) is next.
 
 ## Build commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ npm run lint      # ESLint over src/
 
 ## Development workflow
 
-See `docs/workflow.md` for the full workflow. See `docs/human-interactions.md` for every human approval gate. ADRs live in `docs/adr/`. Planning session summaries live in `docs/sessions/`.
+See `docs/workflow.md` for the full workflow. See `docs/testing.md` for manual testing steps. ADRs live in `docs/adr/`. Planning session summaries live in `docs/sessions/`.
 
 ## Issue number shorthand
 

--- a/docs/design-specification.md
+++ b/docs/design-specification.md
@@ -187,7 +187,7 @@ If `sync-state.json` does not exist, jump to §7 (mass-conflict flow). Do not pr
 ### 5.3 Build the local change set
 
 Before walking, build the exclusion filter:
-1. Start with the plugin's hard-excluded paths: `data.json`, `sync-state.json`, `sync.log` (all under `.obsidian/plugins/<our-id>/`).
+1. Start with the plugin's hard-excluded paths: `data.json`, `sync-state.json`, `sync-state.json.tmp`, `sync.log`, `sync.log.1` (all under `.obsidian/plugins/<our-id>/`).
 2. If a `.gitignore` file exists at the vault root, read it and parse its positive patterns (lines that are not blank, not comments, and do not begin with `!`) into the exclusion list. Negation lines (`!pattern`) are silently ignored for v1.
 3. Append user-configured exclude patterns from settings.
 
@@ -453,6 +453,7 @@ Sections:
 
 - **Ribbon icon** (sync icon, both desktop and mobile). Click = run sync. While syncing, icon spins.
 - **Command palette entry:** "Sync with GitHub" (same action).
+- **Concurrency guard:** ribbon clicks and command invocations are ignored while a sync is already in progress.
 - **Status bar** (desktop only — mobile doesn't have a status bar): "Synced HH:MM" or "Never synced" or "Syncing…" or "Sync error (click for details)."
 
 ### 8.3 Conflict resolution modal

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,9 +4,9 @@ Steps to configure and manually test the plugin across platforms and phases.
 
 ---
 
-## Desktop setup (Phase 2+ gate)
+## Desktop setup (Phase 3+ gate)
 
-Before signing off on any phase from Phase 2 onward, smoke-test the plugin in Obsidian desktop:
+Before signing off on any phase from Phase 3 onward, smoke-test the plugin in Obsidian desktop:
 
 1. Clone the repo into `<your-vault>/.obsidian/plugins/jackdaw/`.
 2. Run `npm install && npm run build`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,7 +23,7 @@ Before signing off on any phase from Phase 3 onward, smoke-test the plugin in Ob
 
 ## iOS manual testing (Phase 5 gate)
 
-Run on a **physical iPhone** — this cannot be delegated or automated.
+Corresponds to §11.3 of the design specification. Run on a **physical iPhone** — this cannot be delegated or automated.
 
 **Setup:**
 1. Install Obsidian on the iPhone.
@@ -34,7 +34,7 @@ Run on a **physical iPhone** — this cannot be delegated or automated.
 
 | # | Scenario | Expected |
 |---|---|---|
-| 1 | First sync against an empty-ish test repo with a few existing files | First-sync modal appears; files are pulled; state is saved |
+| 1 | First sync against an empty-ish test repo with a few existing files | First-sync modal appears; files are pulled; state is saved *(requires Phase 4)* |
 | 2 | Edit a note on iOS only, then sync | Changed file is pushed to GitHub; no pull activity |
 | 3 | Edit a file via GitHub web UI, then sync from iOS | File is pulled and updated in vault; no push |
 | 4 | Edit the same file both locally and on GitHub, then sync | Conflict UI appears; resolving with either option applies cleanly |
@@ -48,7 +48,7 @@ Phase 5 does not close until all scenarios pass.
 
 ## Obsidian Sync coexistence testing (Phase 5 gate)
 
-Requires **two physical devices** both running Obsidian Sync and the Jackdaw plugin connected to the same vault and same test GitHub repo.
+Corresponds to §11.4 of the design specification. Requires **two physical devices** both running Obsidian Sync and the Jackdaw plugin connected to the same vault and same test GitHub repo.
 
 **Scenarios:**
 
@@ -61,5 +61,5 @@ Requires **two physical devices** both running Obsidian Sync and the Jackdaw plu
    - Expected: staleness is detected (local content hash matches remote blob hash despite differing from recorded state); file is treated as a no-op; state is updated silently.
 
 3. **Three-way conflict**
-   - Edit a file on device A, edit a *different* file on device B, and make a third edit via the GitHub web UI → sync from one device.
-   - Expected: only the file edited both locally and remotely appears in the conflict UI; the other file is pushed or pulled cleanly.
+   - Edit file X on device A. Edit file X via the GitHub web UI (creating a conflict on file X). Edit a different file Y on device B. Sync from device A.
+   - Expected: file X appears in the conflict UI; file Y is pushed cleanly; resolving the conflict applies without errors.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,65 @@
+# Manual Testing
+
+Steps to configure and manually test the plugin across platforms and phases.
+
+---
+
+## Desktop setup (Phase 2+ gate)
+
+Before signing off on any phase from Phase 2 onward, smoke-test the plugin in Obsidian desktop:
+
+1. Clone the repo into `<your-vault>/.obsidian/plugins/jackdaw/`.
+2. Run `npm install && npm run build`.
+3. In Obsidian → Settings → Community plugins, disable Safe mode and enable **Jackdaw**.
+4. Open Settings → Jackdaw and enter:
+   - **PAT** — a GitHub personal access token with `repo` scope.
+   - **Repository** — `owner/repo` of a small test repo you control.
+   - **Branch** — the branch to sync against (e.g. `main`).
+5. Click the sync ribbon icon. Verify the status bar shows "Syncing…" and then a success message.
+6. Make a local edit, sync again, and confirm the change appears in the GitHub repo.
+7. Make a remote edit via the GitHub web UI, sync, and confirm the vault file is updated.
+
+---
+
+## iOS manual testing (Phase 5 gate)
+
+Run on a **physical iPhone** — this cannot be delegated or automated.
+
+**Setup:**
+1. Install Obsidian on the iPhone.
+2. Install the plugin via BRAT (Settings → Community plugins → BRAT → Add beta plugin → paste the repo URL).
+3. Configure PAT, repo, and branch in Settings → Jackdaw using the same small test repo.
+
+**Scenarios — record pass/fail for each:**
+
+| # | Scenario | Expected |
+|---|---|---|
+| 1 | First sync against an empty-ish test repo with a few existing files | First-sync modal appears; files are pulled; state is saved |
+| 2 | Edit a note on iOS only, then sync | Changed file is pushed to GitHub; no pull activity |
+| 3 | Edit a file via GitHub web UI, then sync from iOS | File is pulled and updated in vault; no push |
+| 4 | Edit the same file both locally and on GitHub, then sync | Conflict UI appears; resolving with either option applies cleanly |
+| 5 | Force-quit Obsidian mid-sync, reopen, sync again | Plugin recovers; no duplicate or missing files; `.tmp` file is not left behind |
+| 6 | Attach a file larger than the configured per-file size limit, then sync | File is skipped; a notice explains it was omitted due to size |
+| 7 | Toggle airplane mode immediately after tapping sync | Sync fails gracefully; error notice appears; no partial state written |
+
+Phase 5 does not close until all scenarios pass.
+
+---
+
+## Obsidian Sync coexistence testing (Phase 5 gate)
+
+Requires **two physical devices** both running Obsidian Sync and the Jackdaw plugin connected to the same vault and same test GitHub repo.
+
+**Scenarios:**
+
+1. **Normal two-device flow**
+   - Edit a note on device A → sync to GitHub from A → wait for Obsidian Sync to propagate the updated `sync-state.json` to B → sync from B.
+   - Expected: sync from B is a no-op; no conflict is raised.
+
+2. **Stale state on device B (§4.4 case 3)**
+   - Edit a note on device A → sync from A → immediately sync from B *before* Obsidian Sync has delivered the updated `sync-state.json`.
+   - Expected: staleness is detected (local content hash matches remote blob hash despite differing from recorded state); file is treated as a no-op; state is updated silently.
+
+3. **Three-way conflict**
+   - Edit a file on device A, edit a *different* file on device B, and make a third edit via the GitHub web UI → sync from one device.
+   - Expected: only the file edited both locally and remotely appears in the conflict UI; the other file is pushed or pulled cleanly.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -106,7 +106,7 @@ Example invocation for Phase 2: `/review` — then note in the PR comment prompt
 
 ## CI
 
-GitHub Actions runs lint and type-check on every PR and on pushes to `main`. Configuration lives at `.github/workflows/ci.yml`. The specific npm scripts (`typecheck`, `lint`) are wired up in Phase 0.
+GitHub Actions runs type-check, lint, and unit tests on every PR and on pushes to `main`. Configuration lives at `.github/workflows/ci.yml`. The specific npm scripts (`typecheck`, `lint`, `test`) are wired up in Phase 0.
 
 CI must pass before a PR can be merged.
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -4,8 +4,6 @@
 
 Jackdaw is developed incrementally through Claude Code. Claude handles implementation and plays product/design roles during planning. The human approves at every gate.
 
-See `docs/human-interactions.md` for every point that requires human input.
-
 ---
 
 ## Branch strategy


### PR DESCRIPTION
Replace all remaining references to the now-deleted docs/human-interactions.md
with docs/testing.md. Create docs/testing.md with concrete manual testing steps
for desktop setup, iOS scenarios, and Obsidian Sync coexistence — preserving
the testing content that was in the deleted file.

https://claude.ai/code/session_01HiFCjg2et5DiquHAE4jmvK