### PR TITLE
Read conflict policy lazily in PolicyBasedResolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/
 data.json
 main.js
 node_modules/
+sync.log

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,7 +54,7 @@ export default class JackdawPlugin extends Plugin {
 			logger,
 		);
 
-		const resolver = new PolicyBasedResolver(this.settings.conflictPolicy);
+		const resolver = new PolicyBasedResolver(() => this.settings.conflictPolicy);
 
 		this.engine = new SyncEngine(
 			vault,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,9 +1,11 @@
+export type ConflictPolicy = 'always-ask' | 'always-prefer-local' | 'always-prefer-remote';
+
 export interface Settings {
 	owner: string;
 	repo: string;
 	branch: string;
 	pat: string;
-	conflictPolicy: 'always-ask' | 'always-prefer-local' | 'always-prefer-remote';
+	conflictPolicy: ConflictPolicy;
 	perFileSizeLimitMb: number;
 	deviceName: string;
 	includeObsidianConfig: boolean;

--- a/src/sync-engine-types.ts
+++ b/src/sync-engine-types.ts
@@ -90,12 +90,15 @@ export class SyncStateInconsistencyError extends Error {
 }
 
 export class PolicyBasedResolver implements ConflictResolver, FirstSyncResolver {
-	constructor(private readonly policy: 'always-prefer-local' | 'always-prefer-remote' | 'always-ask') {}
+	constructor(
+		private readonly getPolicy: () => 'always-prefer-local' | 'always-prefer-remote' | 'always-ask',
+	) {}
 
 	resolve(
 		conflicts: ConflictItem[] | FirstSyncSummary
 	): Promise<Map<string, ConflictResolution> | 'cancel'> {
-		if (this.policy === 'always-ask') {
+		const policy = this.getPolicy();
+		if (policy === 'always-ask') {
 			throw new SyncNeedsUIError();
 		}
 
@@ -104,7 +107,7 @@ export class PolicyBasedResolver implements ConflictResolver, FirstSyncResolver 
 			: (conflicts as FirstSyncSummary).conflicts;
 
 		const resolution: ConflictResolution =
-			this.policy === 'always-prefer-local' ? 'keep-local' : 'keep-remote';
+			policy === 'always-prefer-local' ? 'keep-local' : 'keep-remote';
 
 		const result = new Map<string, ConflictResolution>();
 		for (const item of items) {

--- a/src/sync-engine-types.ts
+++ b/src/sync-engine-types.ts
@@ -1,3 +1,5 @@
+import type { ConflictPolicy } from './settings';
+
 export type LocalChangeType = 'added' | 'modified' | 'deleted' | 'unchanged';
 export type RemoteChangeType = 'added' | 'modified' | 'deleted' | 'unchanged';
 
@@ -90,9 +92,7 @@ export class SyncStateInconsistencyError extends Error {
 }
 
 export class PolicyBasedResolver implements ConflictResolver, FirstSyncResolver {
-	constructor(
-		private readonly getPolicy: () => 'always-prefer-local' | 'always-prefer-remote' | 'always-ask',
-	) {}
+	constructor(private readonly getPolicy: () => ConflictPolicy) {}
 
 	resolve(
 		conflicts: ConflictItem[] | FirstSyncSummary

--- a/src/sync-engine.ts
+++ b/src/sync-engine.ts
@@ -87,7 +87,7 @@ export class SyncEngine {
 	): Promise<SyncResult> {
 		const { owner, repo, branch } = settings;
 		let fastForwardRetries = 0;
-		const policyResolver = new PolicyBasedResolver(settings.conflictPolicy);
+		const policyResolver = new PolicyBasedResolver(() => settings.conflictPolicy);
 
 		const report: SyncReport = {
 			filesAdded: 0,

--- a/tests/policy-based-resolver.test.ts
+++ b/tests/policy-based-resolver.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from 'vitest';
+import { PolicyBasedResolver, SyncNeedsUIError } from '../src/sync-engine-types';
+import type { ConflictItem } from '../src/sync-engine-types';
+import type { ConflictPolicy } from '../src/settings';
+
+function makeConflicts(): ConflictItem[] {
+	return [{ path: 'a.md', action: 'conflict', local: 'modified', remote: 'modified' }];
+}
+
+test('reads policy fresh on each resolve — value change after construction takes effect', async () => {
+	let policy: ConflictPolicy = 'always-prefer-local';
+	const resolver = new PolicyBasedResolver(() => policy);
+
+	const first = (await resolver.resolve(makeConflicts())) as Map<string, 'keep-local' | 'keep-remote'>;
+	expect(first.get('a.md')).toBe('keep-local');
+
+	policy = 'always-prefer-remote';
+
+	const second = (await resolver.resolve(makeConflicts())) as Map<string, 'keep-local' | 'keep-remote'>;
+	expect(second.get('a.md')).toBe('keep-remote');
+});
+
+test('switching policy to always-ask after construction throws SyncNeedsUIError', async () => {
+	let policy: ConflictPolicy = 'always-prefer-local';
+	const resolver = new PolicyBasedResolver(() => policy);
+
+	await expect(resolver.resolve(makeConflicts())).resolves.toBeDefined();
+
+	policy = 'always-ask';
+
+	expect(() => resolver.resolve(makeConflicts())).toThrow(SyncNeedsUIError);
+});
+
+test('always-ask at construction throws on resolve', () => {
+	const resolver = new PolicyBasedResolver(() => 'always-ask');
+	expect(() => resolver.resolve(makeConflicts())).toThrow(SyncNeedsUIError);
+});


### PR DESCRIPTION
## Summary

- `PolicyBasedResolver` now takes a getter (`() => policy`) instead of a snapshot value, so the policy is read fresh every time `resolve()` is called.
- `main.ts` and `sync-engine.ts` updated to pass `() => settings.conflictPolicy`.

## Why

The long-lived resolver instance constructed in `main.ts` at plugin load was capturing the conflict policy by value. The `runFirstSync` path uses that instance directly (`this.firstSync`), so changing the conflict policy in settings did not take effect on first sync until the plugin was disabled and re-enabled. `runNormalSync` already happened to dodge this by constructing a fresh resolver per sync, but the first-sync path was fully exposed.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 221/221 pass
- [ ] Manual: with a fresh empty repo and `conflictPolicy: always-prefer-remote`, first sync completes without `SyncNeedsUIError`
- [ ] Manual: changing the conflict policy in settings is picked up by the next sync without a plugin reload

Closes #95