### PR TITLE
Add plugin state files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@ coverage/
 data.json
 main.js
 node_modules/
+sync-state.json
+sync-state.json.tmp
 sync.log
+sync.log.1


### PR DESCRIPTION
## Summary
- Adds `sync-state.json`, `sync-state.json.tmp`, and `sync.log.1` to `.gitignore`
- These are the remaining plugin-internal files in `SELF_EXCLUDED_PATHS` (`src/constants.ts`) that were not already ignored
- They are runtime artifacts created when the plugin is loaded into a vault and must never be checked into the repo

## Test plan
- [x] `git status` in a working tree with the plugin loaded no longer shows `sync-state.json` as untracked
- [x] Existing ignored files (`data.json`, `sync.log`) still ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)