### PR TITLE
Constrain sync log modal pre to scroll within its container

### DIFF
--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -245,7 +245,10 @@ class SyncLogModal extends Modal {
 
 	onOpen(): void {
 		this.titleEl.setText('Sync log');
-		this.contentEl.createEl('pre', { text: this.contents });
+		this.contentEl.createEl('pre', {
+			text: this.contents,
+			attr: { style: 'max-width:100%;overflow-x:auto;' },
+		});
 		new Setting(this.contentEl)
 			.addButton(btn => btn.setButtonText('Close').onClick(() => this.close()));
 	}


### PR DESCRIPTION
## Summary

- Adds `max-width:100%;overflow-x:auto` to the `<pre>` element in `SyncLogModal`
- Long log lines (stack traces, long file paths) now scroll horizontally inside the pre, keeping the modal chrome (title and Close button) visible at all times

## Test plan

- [ ] Enable verbose logging, trigger a sync with long file paths, open Settings → Jackdaw → View sync log — modal chrome should stay in place, only the log area scrolls
- [ ] Verify short/normal log content is unaffected

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)