### PR TITLE
Add Copy button and log file path hint to sync log modal

### DIFF
--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -254,7 +254,17 @@ class SyncLogModal extends Modal {
 			text: this.contents,
 			attr: { style: 'max-width:100%;overflow-x:auto;' },
 		});
+		this.contentEl.createEl('p', {
+			text: `Log file: .obsidian/plugins/${PLUGIN_ID}/sync.log (rotated copy: sync.log.1)`,
+			attr: { style: 'font-size:var(--font-ui-small);color:var(--text-muted);margin-top:0;' },
+		});
 		new Setting(this.contentEl)
+			.addButton(btn =>
+				btn.setButtonText('Copy').onClick(async () => {
+					await navigator.clipboard.writeText(this.contents);
+					new Notice('Log copied to clipboard');
+				}),
+			)
 			.addButton(btn => btn.setButtonText('Close').onClick(() => this.close()));
 	}
 

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -261,8 +261,12 @@ class SyncLogModal extends Modal {
 		new Setting(this.contentEl)
 			.addButton(btn =>
 				btn.setButtonText('Copy').onClick(async () => {
-					await navigator.clipboard.writeText(this.contents);
-					new Notice('Log copied to clipboard');
+					try {
+						await navigator.clipboard.writeText(this.contents);
+						new Notice('Log copied to clipboard');
+					} catch {
+						new Notice('Failed to copy — open the log file directly');
+					}
 				}),
 			)
 			.addButton(btn => btn.setButtonText('Close').onClick(() => this.close()));


### PR DESCRIPTION
## Summary

- Adds a **Copy** button to `SyncLogModal` that writes the full log to the clipboard via `navigator.clipboard.writeText` and shows a `Notice` confirming the copy
- Adds a muted hint below the log showing the log file path and rotated filename (`sync.log.1`) so power users can find the raw files directly

## Test plan

- [ ] Open Settings → Jackdaw → View sync log, click **Copy** — clipboard should contain the full log text and a confirmation notice should appear
- [ ] Verify the log path hint is visible below the log in muted text
- [ ] Verify the **Close** button still works

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)