### PR TITLE
Remove existing sync-state.json before renaming over it

### DIFF
--- a/src/obsidian-state-adapter.ts
+++ b/src/obsidian-state-adapter.ts
@@ -19,4 +19,8 @@ export class ObsidianStateAdapter implements StateAdapter {
 	rename(from: string, to: string): Promise<void> {
 		return this.adapter.rename(from, to);
 	}
+
+	remove(path: string): Promise<void> {
+		return this.adapter.remove(path);
+	}
 }

--- a/src/state-store.ts
+++ b/src/state-store.ts
@@ -25,6 +25,7 @@ export interface StateAdapter {
 	read(path: string): Promise<string>;
 	write(path: string, data: string): Promise<void>;
 	rename(from: string, to: string): Promise<void>;
+	remove(path: string): Promise<void>;
 }
 
 export class StateStore {
@@ -96,6 +97,12 @@ export class StateStore {
 	async save(state: SyncState): Promise<void> {
 		const json = this.pretty ? JSON.stringify(state, null, 2) : JSON.stringify(state);
 		await this.adapter.write(this.tmpPath, json);
+		// Obsidian's DataAdapter.rename throws "Destination file already exists!"
+		// if the destination is present, so clear it first. The load() recovery
+		// path covers the window where tmp exists but canonical does not.
+		if (await this.adapter.exists(this.canonicalPath)) {
+			await this.adapter.remove(this.canonicalPath);
+		}
 		await this.adapter.rename(this.tmpPath, this.canonicalPath);
 	}
 }

--- a/tests/obsidian-state-adapter.test.ts
+++ b/tests/obsidian-state-adapter.test.ts
@@ -8,6 +8,7 @@ function makeDataAdapter(): DataAdapter {
 		read: vi.fn(),
 		write: vi.fn(),
 		rename: vi.fn(),
+		remove: vi.fn(),
 	} as unknown as DataAdapter;
 }
 
@@ -49,5 +50,13 @@ describe('ObsidianStateAdapter', () => {
 		const adapter = new ObsidianStateAdapter(da);
 		await adapter.rename('old/path', 'new/path');
 		expect(da.rename).toHaveBeenCalledWith('old/path', 'new/path');
+	});
+
+	test('remove forwards path unchanged', async () => {
+		const da = makeDataAdapter();
+		vi.mocked(da.remove).mockResolvedValue();
+		const adapter = new ObsidianStateAdapter(da);
+		await adapter.remove('some/path');
+		expect(da.remove).toHaveBeenCalledWith('some/path');
 	});
 });

--- a/tests/state-store.test.ts
+++ b/tests/state-store.test.ts
@@ -10,6 +10,7 @@ interface MockAdapter {
 	read: Mock;
 	write: Mock;
 	rename: Mock;
+	remove: Mock;
 }
 
 function makeAdapter(): MockAdapter {
@@ -18,6 +19,7 @@ function makeAdapter(): MockAdapter {
 		read: vi.fn(),
 		write: vi.fn().mockResolvedValue(undefined),
 		rename: vi.fn().mockResolvedValue(undefined),
+		remove: vi.fn().mockResolvedValue(undefined),
 	};
 }
 
@@ -99,6 +101,53 @@ describe('StateStore', () => {
 			`write:${TMP}`,
 			`rename:${TMP}->${CANONICAL}`,
 		]);
+	});
+
+	test('save: removes existing canonical before rename (Obsidian rename does not overwrite)', async () => {
+		const adapter = makeAdapter();
+		const filesPresent = new Set<string>([CANONICAL]);
+		const callOrder: string[] = [];
+
+		adapter.exists.mockImplementation((path: string) => Promise.resolve(filesPresent.has(path)));
+		adapter.write.mockImplementation((path: string) => {
+			callOrder.push(`write:${path}`);
+			filesPresent.add(path);
+			return Promise.resolve();
+		});
+		adapter.remove.mockImplementation((path: string) => {
+			callOrder.push(`remove:${path}`);
+			filesPresent.delete(path);
+			return Promise.resolve();
+		});
+		adapter.rename.mockImplementation((from: string, to: string) => {
+			callOrder.push(`rename:${from}->${to}`);
+			if (filesPresent.has(to)) {
+				return Promise.reject(new Error('Destination file already exists!'));
+			}
+			filesPresent.delete(from);
+			filesPresent.add(to);
+			return Promise.resolve();
+		});
+
+		const store = new StateStore(asAdapter(adapter), PLUGIN_FOLDER, makeLogger());
+		await expect(store.save(makeState())).resolves.toBeUndefined();
+
+		expect(callOrder).toEqual([
+			`write:${TMP}`,
+			`remove:${CANONICAL}`,
+			`rename:${TMP}->${CANONICAL}`,
+		]);
+	});
+
+	test('save: skips remove when canonical does not exist', async () => {
+		const adapter = makeAdapter();
+		adapter.exists.mockResolvedValue(false);
+
+		const store = new StateStore(asAdapter(adapter), PLUGIN_FOLDER, makeLogger());
+		await store.save(makeState());
+
+		expect(adapter.remove).not.toHaveBeenCalled();
+		expect(adapter.rename).toHaveBeenCalledWith(TMP, CANONICAL);
 	});
 
 	test('recovery: .tmp exists but canonical does not — loads tmp, emits state.recover, renames', async () => {


### PR DESCRIPTION
## Summary

- `StateStore.save` writes to `sync-state.json.tmp` then renames it to `sync-state.json`. Obsidian's `DataAdapter.rename` throws `Destination file already exists!` when the destination is present, so the rename failed on every save where the canonical file already existed (the post-pull save in normal sync, or any sync run after the first).
- Fix mirrors the workaround already used in `Logger.rotate` (`src/logger.ts:56-63`): if the canonical file exists, remove it before renaming. The brief window where only `.tmp` exists is already covered by `load()`'s recovery path.
- Adds a regression test that simulates Obsidian's strict-rename behavior — it fails on the previous code and passes on the fix.

Symptom from the user's sync log:

```
{"event":"sync.commit","commitSha":"c6a4ef..."}
{"event":"sync.error","error":"Destination file already exists!"}
```

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx vitest run` (233 passing)
- [x] Confirmed the new regression test fails without the source change
- [ ] Manual: run a sync that pulls and pushes in the same run, verify no error and `sync-state.json` is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)