### PR TITLE
Add line-level diff utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "jackdaw",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "diff": "^9.0.0"
+      },
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
@@ -1776,6 +1779,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dir-glob": {

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "obsidian": "latest",
     "typescript": "^5.4.0",
     "vitest": "^4.1.5"
+  },
+  "dependencies": {
+    "diff": "^9.0.0"
   }
 }

--- a/src/ui/diff.ts
+++ b/src/ui/diff.ts
@@ -1,0 +1,52 @@
+import { diffLines } from 'diff';
+
+export type DiffLineKind = 'context' | 'add' | 'remove';
+
+export interface DiffLine {
+	kind: DiffLineKind;
+	text: string;
+	localLineNumber?: number;
+	remoteLineNumber?: number;
+}
+
+export function computeLineDiff(localText: string, remoteText: string): DiffLine[] {
+	if (localText === '' && remoteText === '') {
+		return [];
+	}
+
+	const chunks = diffLines(localText, remoteText);
+	const result: DiffLine[] = [];
+	let localCursor = 1;
+	let remoteCursor = 1;
+
+	for (const chunk of chunks) {
+		const lines = splitChunkLines(chunk.value);
+		const kind: DiffLineKind = chunk.added ? 'add' : chunk.removed ? 'remove' : 'context';
+
+		for (const text of lines) {
+			if (kind === 'context') {
+				result.push({
+					kind,
+					text,
+					localLineNumber: localCursor++,
+					remoteLineNumber: remoteCursor++,
+				});
+			} else if (kind === 'add') {
+				result.push({ kind, text, remoteLineNumber: remoteCursor++ });
+			} else {
+				result.push({ kind, text, localLineNumber: localCursor++ });
+			}
+		}
+	}
+
+	return result;
+}
+
+function splitChunkLines(value: string): string[] {
+	if (value === '') return [];
+	const lines = value.split('\n');
+	if (value.endsWith('\n')) {
+		lines.pop();
+	}
+	return lines;
+}

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -1,0 +1,122 @@
+import { describe, test, expect } from 'vitest';
+import { computeLineDiff } from '../src/ui/diff';
+
+describe('computeLineDiff', () => {
+	test('both empty inputs return []', () => {
+		expect(computeLineDiff('', '')).toEqual([]);
+	});
+
+	test('identical inputs are all context', () => {
+		const local = 'alpha\nbeta\ngamma\n';
+		const result = computeLineDiff(local, local);
+		expect(result).toEqual([
+			{ kind: 'context', text: 'alpha', localLineNumber: 1, remoteLineNumber: 1 },
+			{ kind: 'context', text: 'beta', localLineNumber: 2, remoteLineNumber: 2 },
+			{ kind: 'context', text: 'gamma', localLineNumber: 3, remoteLineNumber: 3 },
+		]);
+	});
+
+	test('pure addition: one extra line at end', () => {
+		const local = 'alpha\nbeta\n';
+		const remote = 'alpha\nbeta\ngamma\n';
+		const result = computeLineDiff(local, remote);
+		expect(result).toEqual([
+			{ kind: 'context', text: 'alpha', localLineNumber: 1, remoteLineNumber: 1 },
+			{ kind: 'context', text: 'beta', localLineNumber: 2, remoteLineNumber: 2 },
+			{ kind: 'add', text: 'gamma', remoteLineNumber: 3 },
+		]);
+	});
+
+	test('pure deletion: one line removed from middle', () => {
+		const local = 'alpha\nbeta\ngamma\n';
+		const remote = 'alpha\ngamma\n';
+		const result = computeLineDiff(local, remote);
+		expect(result).toEqual([
+			{ kind: 'context', text: 'alpha', localLineNumber: 1, remoteLineNumber: 1 },
+			{ kind: 'remove', text: 'beta', localLineNumber: 2 },
+			{ kind: 'context', text: 'gamma', localLineNumber: 3, remoteLineNumber: 2 },
+		]);
+	});
+
+	test('replacement: one line removed and one added at same position', () => {
+		const local = 'alpha\nbeta\ngamma\n';
+		const remote = 'alpha\nBETA\ngamma\n';
+		const result = computeLineDiff(local, remote);
+		expect(result).toEqual([
+			{ kind: 'context', text: 'alpha', localLineNumber: 1, remoteLineNumber: 1 },
+			{ kind: 'remove', text: 'beta', localLineNumber: 2 },
+			{ kind: 'add', text: 'BETA', remoteLineNumber: 2 },
+			{ kind: 'context', text: 'gamma', localLineNumber: 3, remoteLineNumber: 3 },
+		]);
+	});
+
+	test('empty local, non-empty remote: all add', () => {
+		const result = computeLineDiff('', 'one\ntwo\nthree\n');
+		expect(result).toEqual([
+			{ kind: 'add', text: 'one', remoteLineNumber: 1 },
+			{ kind: 'add', text: 'two', remoteLineNumber: 2 },
+			{ kind: 'add', text: 'three', remoteLineNumber: 3 },
+		]);
+	});
+
+	test('empty remote, non-empty local: all remove', () => {
+		const result = computeLineDiff('one\ntwo\nthree\n', '');
+		expect(result).toEqual([
+			{ kind: 'remove', text: 'one', localLineNumber: 1 },
+			{ kind: 'remove', text: 'two', localLineNumber: 2 },
+			{ kind: 'remove', text: 'three', localLineNumber: 3 },
+		]);
+	});
+
+	test('line numbering is correct across a multi-hunk diff', () => {
+		const local = ['a', 'b', 'c', 'd', 'e', 'f', 'g'].join('\n') + '\n';
+		const remote = ['a', 'B', 'c', 'd', 'E', 'F', 'g'].join('\n') + '\n';
+		const result = computeLineDiff(local, remote);
+
+		// Walk result and verify cursors stay in sync
+		let nextLocal = 1;
+		let nextRemote = 1;
+		for (const line of result) {
+			if (line.kind === 'context') {
+				expect(line.localLineNumber).toBe(nextLocal++);
+				expect(line.remoteLineNumber).toBe(nextRemote++);
+			} else if (line.kind === 'add') {
+				expect(line.localLineNumber).toBeUndefined();
+				expect(line.remoteLineNumber).toBe(nextRemote++);
+			} else {
+				expect(line.remoteLineNumber).toBeUndefined();
+				expect(line.localLineNumber).toBe(nextLocal++);
+			}
+		}
+		// Total local lines consumed = 7, total remote lines consumed = 7
+		expect(nextLocal).toBe(8);
+		expect(nextRemote).toBe(8);
+
+		// Check the lines that should be removed/added
+		const removed = result.filter(l => l.kind === 'remove').map(l => l.text);
+		const added = result.filter(l => l.kind === 'add').map(l => l.text);
+		expect(removed).toEqual(['b', 'e', 'f']);
+		expect(added).toEqual(['B', 'E', 'F']);
+	});
+
+	test('handles input without trailing newline', () => {
+		const local = 'alpha\nbeta';
+		const remote = 'alpha\nbeta\ngamma';
+		const result = computeLineDiff(local, remote);
+		// We expect alpha and beta to be context, gamma to be added
+		const kinds = result.map(l => `${l.kind}:${l.text}`);
+		expect(kinds).toContain('context:alpha');
+		expect(kinds).toContain('add:gamma');
+	});
+
+	test('preserves blank lines as empty-text entries', () => {
+		const local = 'alpha\n\nbeta\n';
+		const remote = 'alpha\n\nbeta\n';
+		const result = computeLineDiff(local, remote);
+		expect(result).toEqual([
+			{ kind: 'context', text: 'alpha', localLineNumber: 1, remoteLineNumber: 1 },
+			{ kind: 'context', text: '', localLineNumber: 2, remoteLineNumber: 2 },
+			{ kind: 'context', text: 'beta', localLineNumber: 3, remoteLineNumber: 3 },
+		]);
+	});
+});

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -103,10 +103,23 @@ describe('computeLineDiff', () => {
 		const local = 'alpha\nbeta';
 		const remote = 'alpha\nbeta\ngamma';
 		const result = computeLineDiff(local, remote);
-		// We expect alpha and beta to be context, gamma to be added
-		const kinds = result.map(l => `${l.kind}:${l.text}`);
-		expect(kinds).toContain('context:alpha');
-		expect(kinds).toContain('add:gamma');
+		// diffLines treats 'beta' and 'beta\n' as distinct tokens, so the
+		// no-trailing-newline 'beta' is removed and the trailing-newline
+		// 'beta' is re-added. This is an acceptable line-diff limitation.
+		expect(result).toEqual([
+			{ kind: 'context', text: 'alpha', localLineNumber: 1, remoteLineNumber: 1 },
+			{ kind: 'remove', text: 'beta', localLineNumber: 2 },
+			{ kind: 'add', text: 'beta', remoteLineNumber: 2 },
+			{ kind: 'add', text: 'gamma', remoteLineNumber: 3 },
+		]);
+	});
+
+	test('replacement of single-line content without newlines', () => {
+		const result = computeLineDiff('one', 'two');
+		expect(result).toEqual([
+			{ kind: 'remove', text: 'one', localLineNumber: 1 },
+			{ kind: 'add', text: 'two', remoteLineNumber: 1 },
+		]);
 	});
 
 	test('preserves blank lines as empty-text entries', () => {


### PR DESCRIPTION
## Summary
- Adds `src/ui/diff.ts` — a pure `computeLineDiff(localText, remoteText)` that wraps `diffLines` from the `diff` package and returns `DiffLine[]` with `kind` (`context`/`add`/`remove`) and 1-indexed `localLineNumber`/`remoteLineNumber`. Output is in unified-diff order so the conflict and first-sync modals can render either side-by-side or stacked via CSS.
- Adds `diff@^9.0.0` to `dependencies`.
- Adds `tests/diff.test.ts` covering identical / pure-add / pure-delete / replacement / one-empty / both-empty / multi-hunk numbering / no-trailing-newline / single-line replacement / blank lines.

## Bundle size delta
Measured by temporarily importing `computeLineDiff` into `main.ts`, running `npm run build`, then reverting:

- Before: 32,757 bytes
- After (with a consumer): 36,624 bytes
- **Delta: +3,867 bytes (~3.8 KB)**

No module imports `computeLineDiff` in this PR (consumers land in subsequent Phase 4 issues — conflict modal, first-sync modal), so the `main.js` produced by this PR is unchanged at 32,757 bytes. The +3.8 KB materializes when those modals start importing it.

## Test plan
- [x] `npm test` — 244 tests pass (11 new in `tests/diff.test.ts`)
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean; `main.js` unchanged at 32,757 bytes

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)