### PR TITLE
Add ConflictResolutionModal for mid-sync conflicts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@vitest/coverage-v8": "^4.1.5",
         "esbuild": "^0.28.0",
         "eslint": "^8.57.0",
+        "happy-dom": "^20.9.0",
         "obsidian": "latest",
         "typescript": "^5.4.0",
         "vitest": "^4.1.5"
@@ -1173,6 +1174,23 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
@@ -1816,6 +1834,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
@@ -2323,6 +2354,24 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3787,6 +3836,16 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3836,6 +3895,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@vitest/coverage-v8": "^4.1.5",
     "esbuild": "^0.28.0",
     "eslint": "^8.57.0",
+    "happy-dom": "^20.9.0",
     "obsidian": "latest",
     "typescript": "^5.4.0",
     "vitest": "^4.1.5"

--- a/src/first-sync.ts
+++ b/src/first-sync.ts
@@ -64,7 +64,16 @@ export async function buildFirstSyncSummary(
 			if (localBlobSha !== null && localBlobSha === remote.blobSha) {
 				identical.push(path);
 			} else {
-				conflicts.push({ path, action: 'conflict', local: 'added', remote: 'added' });
+				conflicts.push({
+					path,
+					action: 'conflict',
+					local: 'added',
+					remote: 'added',
+					isBinary: local.isBinary,
+					localSize: local.size,
+					remoteSize: remote.size,
+					remoteBlobSha: remote.blobSha,
+				});
 			}
 		}
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { Settings, DEFAULT_SETTINGS } from './settings';
 import { JackdawSettingsTab } from './ui/settings-tab';
 import { RibbonIcon } from './ui/ribbon';
 import { StatusBar } from './ui/status-bar';
+import { ConflictResolutionModal } from './ui/modals/conflict-resolution-modal';
 import { GitHubClient } from './github-client';
 import { Logger } from './logger';
 import { ObsidianStateAdapter } from './obsidian-state-adapter';
@@ -54,7 +55,13 @@ export default class JackdawPlugin extends Plugin {
 			logger,
 		);
 
-		const resolver = new PolicyBasedResolver(() => this.settings.conflictPolicy);
+		const policyResolver = new PolicyBasedResolver(() => this.settings.conflictPolicy);
+		const conflictModal = new ConflictResolutionModal(
+			this.app,
+			vault,
+			client,
+			() => ({ owner: this.settings.owner, repo: this.settings.repo }),
+		);
 
 		this.engine = new SyncEngine(
 			vault,
@@ -62,8 +69,8 @@ export default class JackdawPlugin extends Plugin {
 			stateStore,
 			logger,
 			() => this.settings,
-			resolver,
-			resolver,
+			conflictModal,
+			policyResolver,
 		);
 
 		if (!Platform.isMobileApp) {

--- a/src/sync-engine-types.ts
+++ b/src/sync-engine-types.ts
@@ -29,7 +29,12 @@ export interface ClassifiedPath {
 	remote: RemoteChangeType;
 }
 
-export interface ConflictItem extends ClassifiedPath {}
+export interface ConflictItem extends ClassifiedPath {
+	isBinary: boolean;
+	localSize: number;
+	remoteSize: number;
+	remoteBlobSha?: string;
+}
 
 export interface FirstSyncSummary {
 	localOnly: string[];

--- a/src/sync-engine.ts
+++ b/src/sync-engine.ts
@@ -136,7 +136,19 @@ export class SyncEngine {
 			}
 
 			// Detect and resolve conflicts
-			const conflictItems = classified.filter((c): c is ConflictItem => c.action === 'conflict');
+			const conflictItems: ConflictItem[] = classified
+				.filter((c) => c.action === 'conflict')
+				.map((c) => {
+					const localChange = local.get(c.path);
+					const remoteChange = remote.get(c.path);
+					return {
+						...c,
+						isBinary: localChange?.isBinary ?? remoteChange?.isBinary ?? false,
+						localSize: localChange?.size ?? 0,
+						remoteSize: remoteChange?.size ?? 0,
+						remoteBlobSha: remoteChange?.blobSha,
+					};
+				});
 			await this.logger.debug('sync.conflicts', {
 				count: conflictItems.length,
 				paths: conflictItems.map((c) => c.path),

--- a/src/ui/modals/conflict-resolution-modal.ts
+++ b/src/ui/modals/conflict-resolution-modal.ts
@@ -1,0 +1,254 @@
+import { App, Modal, Platform } from 'obsidian';
+import type {
+	ConflictItem,
+	ConflictResolution,
+	ConflictResolver,
+	VaultAdapter,
+} from '../../sync-engine-types';
+import type { GitHubClient } from '../../github-client';
+import { computeLineDiff } from '../diff';
+import { createConflictRow, type ConflictRowContentState, type ConflictRowController } from './conflict-row';
+import { computeVirtualWindow } from './virtualized-list';
+
+const COLLAPSED_ROW_HEIGHT = 48;
+const LINE_HEIGHT_PX = 20;
+const EXPANDED_PADDING_PX = 16;
+const FIXED_BLOCK_HEIGHT_PX = 60;
+const OVERSCAN = 3;
+
+export interface RepoCoords {
+	owner: string;
+	repo: string;
+}
+
+export class ConflictResolutionModal extends Modal implements ConflictResolver {
+	private readonly vault: VaultAdapter;
+	private readonly client: GitHubClient;
+	private readonly getRepoCoords: () => RepoCoords;
+
+	private conflicts: ConflictItem[] = [];
+	private readonly selections = new Map<string, ConflictResolution>();
+	private readonly expanded = new Map<string, boolean>();
+	private readonly contentCache = new Map<string, ConflictRowContentState>();
+	private readonly rowControllers = new Map<string, ConflictRowController>();
+
+	private listEl: HTMLElement | null = null;
+	private spacerEl: HTMLElement | null = null;
+	private applyBtn: HTMLButtonElement | null = null;
+	private resolvePromise: ((value: Map<string, ConflictResolution> | 'cancel') => void) | null = null;
+	private settled = false;
+
+	constructor(app: App, vault: VaultAdapter, client: GitHubClient, getRepoCoords: () => RepoCoords) {
+		super(app);
+		this.vault = vault;
+		this.client = client;
+		this.getRepoCoords = getRepoCoords;
+	}
+
+	resolve(conflicts: ConflictItem[]): Promise<Map<string, ConflictResolution> | 'cancel'> {
+		this.conflicts = conflicts;
+		this.settled = false;
+		this.selections.clear();
+		this.expanded.clear();
+		this.contentCache.clear();
+		this.rowControllers.clear();
+
+		return new Promise((resolve) => {
+			this.resolvePromise = resolve;
+			this.open();
+		});
+	}
+
+	onOpen(): void {
+		const { contentEl, modalEl } = this;
+		contentEl.empty();
+
+		modalEl.classList.add('jackdaw-conflict-modal');
+		if (Platform.isMobileApp) {
+			modalEl.classList.add('jackdaw-mobile');
+		}
+
+		this.titleEl.setText(`Resolve ${this.conflicts.length} conflict${this.conflicts.length === 1 ? '' : 's'}.`);
+
+		this.listEl = contentEl.createDiv({ cls: 'jackdaw-conflict-list' });
+		this.spacerEl = this.listEl.createDiv({ cls: 'jackdaw-conflict-list-spacer' });
+
+		this.listEl.addEventListener('scroll', () => this.renderVisible());
+
+		const footer = contentEl.createDiv({ cls: 'jackdaw-conflict-footer' });
+
+		const cancelBtn = footer.createEl('button', { text: 'Cancel sync' });
+		cancelBtn.addEventListener('click', () => this.settle('cancel'));
+
+		const applyBtn = footer.createEl('button', { text: 'Apply selections and sync' });
+		applyBtn.classList.add('mod-cta');
+		applyBtn.addEventListener('click', () => {
+			if (this.selections.size === this.conflicts.length) {
+				this.settle(new Map(this.selections));
+			}
+		});
+		this.applyBtn = applyBtn;
+
+		this.updateApplyButtonState();
+		this.renderVisible();
+	}
+
+	onClose(): void {
+		if (!this.settled) {
+			this.settle('cancel');
+		}
+		this.contentEl.empty();
+		this.modalEl.classList.remove('jackdaw-conflict-modal', 'jackdaw-mobile');
+		this.rowControllers.clear();
+		this.listEl = null;
+		this.spacerEl = null;
+		this.applyBtn = null;
+	}
+
+	private settle(value: Map<string, ConflictResolution> | 'cancel'): void {
+		if (this.settled) return;
+		this.settled = true;
+		const resolver = this.resolvePromise;
+		this.resolvePromise = null;
+		this.close();
+		resolver?.(value);
+	}
+
+	private getRowHeight(index: number): number {
+		const item = this.conflicts[index];
+		if (!this.expanded.get(item.path)) {
+			return COLLAPSED_ROW_HEIGHT;
+		}
+		const cached = this.contentCache.get(item.path);
+		if (!cached || cached.status === 'loading' || cached.status === 'error' || cached.status === 'binary') {
+			return COLLAPSED_ROW_HEIGHT + FIXED_BLOCK_HEIGHT_PX;
+		}
+		return COLLAPSED_ROW_HEIGHT + EXPANDED_PADDING_PX + cached.lines.length * LINE_HEIGHT_PX;
+	}
+
+	private renderVisible(): void {
+		if (!this.listEl || !this.spacerEl) return;
+
+		const window = computeVirtualWindow({
+			scrollTop: this.listEl.scrollTop,
+			viewportHeight: this.listEl.clientHeight,
+			itemCount: this.conflicts.length,
+			getItemHeight: (i) => this.getRowHeight(i),
+			overscan: OVERSCAN,
+		});
+
+		this.spacerEl.style.height = `${window.totalHeight}px`;
+
+		const visiblePaths = new Set<string>();
+		let cumulative = 0;
+		for (let i = 0; i < window.startIndex; i++) {
+			cumulative += this.getRowHeight(i);
+		}
+
+		for (let i = window.startIndex; i < window.endIndex; i++) {
+			const item = this.conflicts[i];
+			visiblePaths.add(item.path);
+			let controller = this.rowControllers.get(item.path);
+			if (!controller) {
+				controller = createConflictRow({
+					item,
+					initialResolution: this.selections.get(item.path) ?? null,
+					initialExpanded: this.expanded.get(item.path) ?? false,
+					onSelect: (resolution) => this.handleSelect(item.path, resolution),
+					onToggle: () => this.handleToggle(item),
+				});
+				this.rowControllers.set(item.path, controller);
+				this.spacerEl.appendChild(controller.el);
+				const cached = this.contentCache.get(item.path);
+				if (cached) controller.setContent(cached);
+			}
+			controller.el.style.position = 'absolute';
+			controller.el.style.left = '0';
+			controller.el.style.right = '0';
+			controller.el.style.top = `${cumulative}px`;
+			cumulative += this.getRowHeight(i);
+		}
+
+		for (const [path, controller] of this.rowControllers) {
+			if (!visiblePaths.has(path)) {
+				controller.el.remove();
+				this.rowControllers.delete(path);
+			}
+		}
+	}
+
+	private handleSelect(path: string, resolution: ConflictResolution): void {
+		this.selections.set(path, resolution);
+		const controller = this.rowControllers.get(path);
+		controller?.setResolution(resolution);
+		this.updateApplyButtonState();
+	}
+
+	private handleToggle(item: ConflictItem): void {
+		const path = item.path;
+		const wasExpanded = this.expanded.get(path) ?? false;
+		const nowExpanded = !wasExpanded;
+		this.expanded.set(path, nowExpanded);
+		const controller = this.rowControllers.get(path);
+		controller?.setExpanded(nowExpanded);
+
+		if (nowExpanded && !this.contentCache.has(path)) {
+			void this.loadContent(item);
+		}
+
+		this.renderVisible();
+	}
+
+	private async loadContent(item: ConflictItem): Promise<void> {
+		this.contentCache.set(item.path, { status: 'loading' });
+		this.rowControllers.get(item.path)?.setContent({ status: 'loading' });
+		this.renderVisible();
+
+		try {
+			if (item.isBinary) {
+				const state: ConflictRowContentState = {
+					status: 'binary',
+					localSize: item.localSize,
+					remoteSize: item.remoteSize,
+				};
+				this.contentCache.set(item.path, state);
+				this.rowControllers.get(item.path)?.setContent(state);
+				this.renderVisible();
+				return;
+			}
+
+			const localText = item.local === 'deleted' ? '' : await this.readLocalText(item.path);
+			const remoteText =
+				item.remote === 'deleted' || !item.remoteBlobSha
+					? ''
+					: await this.readRemoteText(item.remoteBlobSha);
+			const lines = computeLineDiff(localText, remoteText);
+			const state: ConflictRowContentState = { status: 'text', lines };
+			this.contentCache.set(item.path, state);
+			this.rowControllers.get(item.path)?.setContent(state);
+			this.renderVisible();
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			const state: ConflictRowContentState = { status: 'error', message };
+			this.contentCache.set(item.path, state);
+			this.rowControllers.get(item.path)?.setContent(state);
+			this.renderVisible();
+		}
+	}
+
+	private async readLocalText(path: string): Promise<string> {
+		if (!(await this.vault.exists(path))) return '';
+		return this.vault.readText(path);
+	}
+
+	private async readRemoteText(blobSha: string): Promise<string> {
+		const { owner, repo } = this.getRepoCoords();
+		const buf = await this.client.getBlob(owner, repo, blobSha);
+		return new TextDecoder().decode(buf);
+	}
+
+	private updateApplyButtonState(): void {
+		if (!this.applyBtn) return;
+		this.applyBtn.disabled = this.selections.size < this.conflicts.length;
+	}
+}

--- a/src/ui/modals/conflict-resolution-modal.ts
+++ b/src/ui/modals/conflict-resolution-modal.ts
@@ -129,7 +129,7 @@ export class ConflictResolutionModal extends Modal implements ConflictResolver {
 	private renderVisible(): void {
 		if (!this.listEl || !this.spacerEl) return;
 
-		const window = computeVirtualWindow({
+		const view = computeVirtualWindow({
 			scrollTop: this.listEl.scrollTop,
 			viewportHeight: this.listEl.clientHeight,
 			itemCount: this.conflicts.length,
@@ -137,15 +137,12 @@ export class ConflictResolutionModal extends Modal implements ConflictResolver {
 			overscan: OVERSCAN,
 		});
 
-		this.spacerEl.style.height = `${window.totalHeight}px`;
+		this.spacerEl.style.height = `${view.totalHeight}px`;
 
 		const visiblePaths = new Set<string>();
-		let cumulative = 0;
-		for (let i = 0; i < window.startIndex; i++) {
-			cumulative += this.getRowHeight(i);
-		}
+		let cumulative = view.offsetY;
 
-		for (let i = window.startIndex; i < window.endIndex; i++) {
+		for (let i = view.startIndex; i < view.endIndex; i++) {
 			const item = this.conflicts[i];
 			visiblePaths.add(item.path);
 			let controller = this.rowControllers.get(item.path);
@@ -157,14 +154,14 @@ export class ConflictResolutionModal extends Modal implements ConflictResolver {
 					onSelect: (resolution) => this.handleSelect(item.path, resolution),
 					onToggle: () => this.handleToggle(item),
 				});
+				controller.el.style.position = 'absolute';
+				controller.el.style.left = '0';
+				controller.el.style.right = '0';
 				this.rowControllers.set(item.path, controller);
 				this.spacerEl.appendChild(controller.el);
 				const cached = this.contentCache.get(item.path);
 				if (cached) controller.setContent(cached);
 			}
-			controller.el.style.position = 'absolute';
-			controller.el.style.left = '0';
-			controller.el.style.right = '0';
 			controller.el.style.top = `${cumulative}px`;
 			cumulative += this.getRowHeight(i);
 		}

--- a/src/ui/modals/conflict-row.ts
+++ b/src/ui/modals/conflict-row.ts
@@ -1,0 +1,116 @@
+import type { DiffLine } from '../diff';
+import type { ConflictItem, ConflictResolution } from '../../sync-engine-types';
+
+export type ConflictRowContentState =
+	| { status: 'loading' }
+	| { status: 'error'; message: string }
+	| { status: 'binary'; localSize: number; remoteSize: number }
+	| { status: 'text'; lines: DiffLine[] };
+
+export interface ConflictRowOptions {
+	item: ConflictItem;
+	initialResolution: ConflictResolution | null;
+	initialExpanded: boolean;
+	onSelect: (resolution: ConflictResolution) => void;
+	onToggle: () => void;
+}
+
+export interface ConflictRowController {
+	el: HTMLElement;
+	setResolution(resolution: ConflictResolution | null): void;
+	setExpanded(expanded: boolean): void;
+	setContent(content: ConflictRowContentState): void;
+}
+
+export function createConflictRow(opts: ConflictRowOptions): ConflictRowController {
+	const root = document.createElement('div');
+	root.classList.add('jackdaw-conflict-row');
+	root.dataset.path = opts.item.path;
+
+	const header = document.createElement('div');
+	header.classList.add('jackdaw-conflict-row-header');
+
+	const caret = document.createElement('button');
+	caret.type = 'button';
+	caret.classList.add('jackdaw-conflict-row-caret');
+	caret.setAttribute('aria-label', 'Toggle diff view');
+	caret.addEventListener('click', () => opts.onToggle());
+
+	const pathEl = document.createElement('span');
+	pathEl.classList.add('jackdaw-conflict-row-path');
+	pathEl.textContent = opts.item.path;
+
+	const keepLocalBtn = document.createElement('button');
+	keepLocalBtn.type = 'button';
+	keepLocalBtn.classList.add('jackdaw-conflict-row-button', 'jackdaw-keep-local');
+	keepLocalBtn.textContent = 'Keep local';
+	keepLocalBtn.addEventListener('click', () => opts.onSelect('keep-local'));
+
+	const keepRemoteBtn = document.createElement('button');
+	keepRemoteBtn.type = 'button';
+	keepRemoteBtn.classList.add('jackdaw-conflict-row-button', 'jackdaw-keep-remote');
+	keepRemoteBtn.textContent = 'Keep remote';
+	keepRemoteBtn.addEventListener('click', () => opts.onSelect('keep-remote'));
+
+	header.append(caret, pathEl, keepLocalBtn, keepRemoteBtn);
+
+	const body = document.createElement('div');
+	body.classList.add('jackdaw-conflict-row-body');
+
+	root.append(header, body);
+
+	function setResolution(resolution: ConflictResolution | null): void {
+		keepLocalBtn.classList.toggle('jackdaw-selected', resolution === 'keep-local');
+		keepRemoteBtn.classList.toggle('jackdaw-selected', resolution === 'keep-remote');
+		root.classList.toggle('jackdaw-resolved', resolution !== null);
+	}
+
+	function setExpanded(expanded: boolean): void {
+		root.classList.toggle('jackdaw-expanded', expanded);
+		caret.setAttribute('aria-expanded', String(expanded));
+	}
+
+	function setContent(content: ConflictRowContentState): void {
+		while (body.firstChild) body.removeChild(body.firstChild);
+
+		if (content.status === 'loading') {
+			const el = document.createElement('div');
+			el.classList.add('jackdaw-conflict-row-loading');
+			el.textContent = 'Loading…';
+			body.append(el);
+			return;
+		}
+
+		if (content.status === 'error') {
+			const el = document.createElement('div');
+			el.classList.add('jackdaw-conflict-row-error');
+			el.textContent = content.message;
+			body.append(el);
+			return;
+		}
+
+		if (content.status === 'binary') {
+			const el = document.createElement('div');
+			el.classList.add('jackdaw-conflict-row-binary');
+			el.textContent = `(binary file, ${content.localSize} bytes locally, ${content.remoteSize} bytes remotely)`;
+			body.append(el);
+			return;
+		}
+
+		const list = document.createElement('div');
+		list.classList.add('jackdaw-diff');
+		for (const line of content.lines) {
+			const lineEl = document.createElement('div');
+			lineEl.classList.add('jackdaw-diff-line', `jackdaw-diff-${line.kind}`);
+			lineEl.dataset.kind = line.kind;
+			lineEl.textContent = line.text;
+			list.append(lineEl);
+		}
+		body.append(list);
+	}
+
+	setResolution(opts.initialResolution);
+	setExpanded(opts.initialExpanded);
+
+	return { el: root, setResolution, setExpanded, setContent };
+}

--- a/src/ui/modals/virtualized-list.ts
+++ b/src/ui/modals/virtualized-list.ts
@@ -1,0 +1,60 @@
+export interface VirtualWindow {
+	startIndex: number;
+	endIndex: number;
+	totalHeight: number;
+	offsetY: number;
+}
+
+export interface VirtualWindowParams {
+	scrollTop: number;
+	viewportHeight: number;
+	itemCount: number;
+	getItemHeight: (index: number) => number;
+	overscan?: number;
+}
+
+export function computeVirtualWindow(params: VirtualWindowParams): VirtualWindow {
+	const overscan = params.overscan ?? 3;
+	const { scrollTop, viewportHeight, itemCount, getItemHeight } = params;
+
+	if (itemCount === 0) {
+		return { startIndex: 0, endIndex: 0, totalHeight: 0, offsetY: 0 };
+	}
+
+	const top = Math.max(0, scrollTop);
+	const bottom = top + Math.max(0, viewportHeight);
+
+	let cumulative = 0;
+	let startIndex = -1;
+	let endIndex = itemCount;
+	let offsetY = 0;
+
+	for (let i = 0; i < itemCount; i++) {
+		const h = getItemHeight(i);
+		if (startIndex === -1 && cumulative + h > top) {
+			startIndex = i;
+			offsetY = cumulative;
+		}
+		if (endIndex === itemCount && cumulative >= bottom) {
+			endIndex = i;
+		}
+		cumulative += h;
+	}
+
+	if (startIndex === -1) {
+		return {
+			startIndex: itemCount,
+			endIndex: itemCount,
+			totalHeight: cumulative,
+			offsetY: cumulative,
+		};
+	}
+
+	for (let k = 0; k < overscan && startIndex > 0; k++) {
+		startIndex--;
+		offsetY -= getItemHeight(startIndex);
+	}
+	endIndex = Math.min(itemCount, endIndex + overscan);
+
+	return { startIndex, endIndex, totalHeight: cumulative, offsetY };
+}

--- a/styles.css
+++ b/styles.css
@@ -4,3 +4,161 @@
 @keyframes jackdaw-spin {
   to { transform: rotate(360deg); }
 }
+
+.jackdaw-conflict-modal {
+  width: min(90vw, 900px);
+  max-height: 85vh;
+}
+
+.jackdaw-conflict-list {
+  position: relative;
+  overflow-y: auto;
+  max-height: 60vh;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  margin-bottom: 1em;
+}
+
+.jackdaw-conflict-list-spacer {
+  position: relative;
+  width: 100%;
+}
+
+.jackdaw-conflict-row {
+  background: var(--background-primary);
+  border-bottom: 1px solid var(--background-modifier-border);
+  box-sizing: border-box;
+}
+
+.jackdaw-conflict-row.jackdaw-resolved {
+  background: var(--background-modifier-success-rgb, var(--background-secondary));
+}
+
+.jackdaw-conflict-row-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  padding: 0.5em 0.75em;
+  height: 48px;
+  box-sizing: border-box;
+}
+
+.jackdaw-conflict-row-caret {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 0.25em;
+  font-size: 0.75em;
+  color: var(--text-muted);
+  width: 1.5em;
+  text-align: center;
+}
+
+.jackdaw-conflict-row-caret::before {
+  content: "▶";
+  display: inline-block;
+  transition: transform 0.1s ease;
+}
+
+.jackdaw-conflict-row.jackdaw-expanded .jackdaw-conflict-row-caret::before {
+  transform: rotate(90deg);
+}
+
+.jackdaw-conflict-row-path {
+  flex: 1 1 auto;
+  font-family: var(--font-monospace);
+  font-size: 0.9em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.jackdaw-conflict-row-button {
+  flex: 0 0 auto;
+  padding: 0.25em 0.75em;
+  border-radius: 999px;
+  border: 1px solid var(--background-modifier-border);
+  background: var(--background-primary);
+  cursor: pointer;
+  font-size: 0.85em;
+}
+
+.jackdaw-conflict-row-button.jackdaw-selected {
+  background: var(--interactive-accent);
+  color: var(--text-on-accent);
+  border-color: var(--interactive-accent);
+}
+
+.jackdaw-conflict-row-body {
+  display: none;
+  padding: 0.5em 0.75em 0.75em;
+  border-top: 1px dashed var(--background-modifier-border);
+}
+
+.jackdaw-conflict-row.jackdaw-expanded .jackdaw-conflict-row-body {
+  display: block;
+}
+
+.jackdaw-conflict-row-loading,
+.jackdaw-conflict-row-error,
+.jackdaw-conflict-row-binary {
+  font-size: 0.85em;
+  color: var(--text-muted);
+  padding: 0.5em 0;
+}
+
+.jackdaw-conflict-row-error {
+  color: var(--text-error);
+}
+
+.jackdaw-diff {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  font-family: var(--font-monospace);
+  font-size: 0.85em;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.jackdaw-diff-line {
+  padding: 0 0.5em;
+  line-height: 20px;
+}
+
+.jackdaw-diff-context {
+  grid-column: 1 / -1;
+  background: transparent;
+}
+
+.jackdaw-diff-remove {
+  grid-column: 1 / 2;
+  background: var(--background-modifier-error-rgb, rgba(220, 53, 69, 0.15));
+  color: var(--text-error);
+}
+
+.jackdaw-diff-add {
+  grid-column: 2 / 3;
+  background: var(--background-modifier-success-rgb, rgba(40, 167, 69, 0.15));
+  color: var(--text-success);
+}
+
+.jackdaw-mobile .jackdaw-diff {
+  display: block;
+}
+
+.jackdaw-mobile .jackdaw-diff-line {
+  grid-column: auto;
+}
+
+.jackdaw-conflict-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5em;
+  padding-top: 0.5em;
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.jackdaw-conflict-footer button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/styles.css
+++ b/styles.css
@@ -31,7 +31,7 @@
 }
 
 .jackdaw-conflict-row.jackdaw-resolved {
-  background: var(--background-modifier-success-rgb, var(--background-secondary));
+  background: var(--background-secondary);
 }
 
 .jackdaw-conflict-row-header {
@@ -132,13 +132,13 @@
 
 .jackdaw-diff-remove {
   grid-column: 1 / 2;
-  background: var(--background-modifier-error-rgb, rgba(220, 53, 69, 0.15));
+  background: var(--background-modifier-error);
   color: var(--text-error);
 }
 
 .jackdaw-diff-add {
   grid-column: 2 / 3;
-  background: var(--background-modifier-success-rgb, rgba(40, 167, 69, 0.15));
+  background: var(--background-modifier-success);
   color: var(--text-success);
 }
 

--- a/tests/conflict-row.test.ts
+++ b/tests/conflict-row.test.ts
@@ -1,0 +1,211 @@
+// @vitest-environment happy-dom
+import { describe, test, expect, vi } from 'vitest';
+import { createConflictRow } from '../src/ui/modals/conflict-row';
+import type { ConflictItem } from '../src/sync-engine-types';
+
+function makeItem(overrides: Partial<ConflictItem> = {}): ConflictItem {
+	return {
+		path: 'notes/foo.md',
+		action: 'conflict',
+		local: 'modified',
+		remote: 'modified',
+		isBinary: false,
+		localSize: 100,
+		remoteSize: 120,
+		...overrides,
+	};
+}
+
+describe('createConflictRow', () => {
+	test('renders collapsed row with path and two buttons', () => {
+		const row = createConflictRow({
+			item: makeItem(),
+			initialResolution: null,
+			initialExpanded: false,
+			onSelect: () => {},
+			onToggle: () => {},
+		});
+
+		expect(row.el.classList.contains('jackdaw-conflict-row')).toBe(true);
+		expect(row.el.classList.contains('jackdaw-expanded')).toBe(false);
+		expect(row.el.dataset.path).toBe('notes/foo.md');
+		expect(row.el.querySelector('.jackdaw-conflict-row-path')?.textContent).toBe('notes/foo.md');
+		expect(row.el.querySelectorAll('.jackdaw-conflict-row-button').length).toBe(2);
+	});
+
+	test('clicking Keep local invokes onSelect with keep-local', () => {
+		const onSelect = vi.fn();
+		const row = createConflictRow({
+			item: makeItem(),
+			initialResolution: null,
+			initialExpanded: false,
+			onSelect,
+			onToggle: () => {},
+		});
+		const btn = row.el.querySelector('.jackdaw-keep-local') as HTMLButtonElement;
+		btn.click();
+		expect(onSelect).toHaveBeenCalledWith('keep-local');
+	});
+
+	test('clicking Keep remote invokes onSelect with keep-remote', () => {
+		const onSelect = vi.fn();
+		const row = createConflictRow({
+			item: makeItem(),
+			initialResolution: null,
+			initialExpanded: false,
+			onSelect,
+			onToggle: () => {},
+		});
+		const btn = row.el.querySelector('.jackdaw-keep-remote') as HTMLButtonElement;
+		btn.click();
+		expect(onSelect).toHaveBeenCalledWith('keep-remote');
+	});
+
+	test('caret click invokes onToggle', () => {
+		const onToggle = vi.fn();
+		const row = createConflictRow({
+			item: makeItem(),
+			initialResolution: null,
+			initialExpanded: false,
+			onSelect: () => {},
+			onToggle,
+		});
+		const caret = row.el.querySelector('.jackdaw-conflict-row-caret') as HTMLButtonElement;
+		caret.click();
+		expect(onToggle).toHaveBeenCalled();
+	});
+
+	test('setResolution highlights the selected button and adds resolved class', () => {
+		const row = createConflictRow({
+			item: makeItem(),
+			initialResolution: null,
+			initialExpanded: false,
+			onSelect: () => {},
+			onToggle: () => {},
+		});
+		const localBtn = row.el.querySelector('.jackdaw-keep-local') as HTMLElement;
+		const remoteBtn = row.el.querySelector('.jackdaw-keep-remote') as HTMLElement;
+
+		row.setResolution('keep-local');
+		expect(localBtn.classList.contains('jackdaw-selected')).toBe(true);
+		expect(remoteBtn.classList.contains('jackdaw-selected')).toBe(false);
+		expect(row.el.classList.contains('jackdaw-resolved')).toBe(true);
+
+		row.setResolution('keep-remote');
+		expect(localBtn.classList.contains('jackdaw-selected')).toBe(false);
+		expect(remoteBtn.classList.contains('jackdaw-selected')).toBe(true);
+
+		row.setResolution(null);
+		expect(localBtn.classList.contains('jackdaw-selected')).toBe(false);
+		expect(remoteBtn.classList.contains('jackdaw-selected')).toBe(false);
+		expect(row.el.classList.contains('jackdaw-resolved')).toBe(false);
+	});
+
+	test('setExpanded toggles jackdaw-expanded class and aria-expanded', () => {
+		const row = createConflictRow({
+			item: makeItem(),
+			initialResolution: null,
+			initialExpanded: false,
+			onSelect: () => {},
+			onToggle: () => {},
+		});
+		const caret = row.el.querySelector('.jackdaw-conflict-row-caret') as HTMLElement;
+
+		row.setExpanded(true);
+		expect(row.el.classList.contains('jackdaw-expanded')).toBe(true);
+		expect(caret.getAttribute('aria-expanded')).toBe('true');
+
+		row.setExpanded(false);
+		expect(row.el.classList.contains('jackdaw-expanded')).toBe(false);
+		expect(caret.getAttribute('aria-expanded')).toBe('false');
+	});
+
+	test('initialExpanded=true starts in expanded state', () => {
+		const row = createConflictRow({
+			item: makeItem(),
+			initialResolution: null,
+			initialExpanded: true,
+			onSelect: () => {},
+			onToggle: () => {},
+		});
+		expect(row.el.classList.contains('jackdaw-expanded')).toBe(true);
+	});
+
+	test('setContent renders loading state', () => {
+		const row = createConflictRow({
+			item: makeItem(),
+			initialResolution: null,
+			initialExpanded: true,
+			onSelect: () => {},
+			onToggle: () => {},
+		});
+		row.setContent({ status: 'loading' });
+		expect(row.el.querySelector('.jackdaw-conflict-row-loading')?.textContent).toBe('Loading…');
+	});
+
+	test('setContent renders error message', () => {
+		const row = createConflictRow({
+			item: makeItem(),
+			initialResolution: null,
+			initialExpanded: true,
+			onSelect: () => {},
+			onToggle: () => {},
+		});
+		row.setContent({ status: 'error', message: 'Network error' });
+		expect(row.el.querySelector('.jackdaw-conflict-row-error')?.textContent).toBe('Network error');
+	});
+
+	test('setContent renders binary byte-count summary', () => {
+		const row = createConflictRow({
+			item: makeItem({ isBinary: true, localSize: 1024, remoteSize: 2048 }),
+			initialResolution: null,
+			initialExpanded: true,
+			onSelect: () => {},
+			onToggle: () => {},
+		});
+		row.setContent({ status: 'binary', localSize: 1024, remoteSize: 2048 });
+		const text = row.el.querySelector('.jackdaw-conflict-row-binary')?.textContent;
+		expect(text).toBe('(binary file, 1024 bytes locally, 2048 bytes remotely)');
+	});
+
+	test('setContent renders text diff lines with kind classes', () => {
+		const row = createConflictRow({
+			item: makeItem(),
+			initialResolution: null,
+			initialExpanded: true,
+			onSelect: () => {},
+			onToggle: () => {},
+		});
+		row.setContent({
+			status: 'text',
+			lines: [
+				{ kind: 'context', text: 'unchanged', localLineNumber: 1, remoteLineNumber: 1 },
+				{ kind: 'remove', text: 'old', localLineNumber: 2 },
+				{ kind: 'add', text: 'new', remoteLineNumber: 2 },
+			],
+		});
+		const lineEls = row.el.querySelectorAll('.jackdaw-diff-line');
+		expect(lineEls.length).toBe(3);
+		expect(lineEls[0].classList.contains('jackdaw-diff-context')).toBe(true);
+		expect(lineEls[0].textContent).toBe('unchanged');
+		expect((lineEls[0] as HTMLElement).dataset.kind).toBe('context');
+		expect(lineEls[1].classList.contains('jackdaw-diff-remove')).toBe(true);
+		expect(lineEls[1].textContent).toBe('old');
+		expect(lineEls[2].classList.contains('jackdaw-diff-add')).toBe(true);
+		expect(lineEls[2].textContent).toBe('new');
+	});
+
+	test('setContent replaces previous content rather than appending', () => {
+		const row = createConflictRow({
+			item: makeItem(),
+			initialResolution: null,
+			initialExpanded: true,
+			onSelect: () => {},
+			onToggle: () => {},
+		});
+		row.setContent({ status: 'loading' });
+		row.setContent({ status: 'binary', localSize: 10, remoteSize: 20 });
+		expect(row.el.querySelectorAll('.jackdaw-conflict-row-loading').length).toBe(0);
+		expect(row.el.querySelectorAll('.jackdaw-conflict-row-binary').length).toBe(1);
+	});
+});

--- a/tests/policy-based-resolver.test.ts
+++ b/tests/policy-based-resolver.test.ts
@@ -4,7 +4,17 @@ import type { ConflictItem } from '../src/sync-engine-types';
 import type { ConflictPolicy } from '../src/settings';
 
 function makeConflicts(): ConflictItem[] {
-	return [{ path: 'a.md', action: 'conflict', local: 'modified', remote: 'modified' }];
+	return [
+		{
+			path: 'a.md',
+			action: 'conflict',
+			local: 'modified',
+			remote: 'modified',
+			isBinary: false,
+			localSize: 0,
+			remoteSize: 0,
+		},
+	];
 }
 
 test('reads policy fresh on each resolve — value change after construction takes effect', async () => {

--- a/tests/sync-engine.test.ts
+++ b/tests/sync-engine.test.ts
@@ -474,7 +474,15 @@ describe('normal sync', () => {
 
 		const result = await engine.sync();
 
-		expect(conflicts.resolve).toHaveBeenCalledWith([conflictPath]);
+		expect(conflicts.resolve).toHaveBeenCalledWith([
+			{
+				...conflictPath,
+				isBinary: false,
+				localSize: 0,
+				remoteSize: 0,
+				remoteBlobSha: undefined,
+			},
+		]);
 		expect(result.status).toBe('cancelled');
 	});
 
@@ -499,7 +507,15 @@ describe('normal sync', () => {
 
 		const result = await engine.sync();
 
-		expect(conflicts.resolve).toHaveBeenCalledWith([conflictPath]);
+		expect(conflicts.resolve).toHaveBeenCalledWith([
+			{
+				...conflictPath,
+				isBinary: false,
+				localSize: 10,
+				remoteSize: 10,
+				remoteBlobSha: 'blob-conflict.md',
+			},
+		]);
 		expect(applyPush).toHaveBeenCalledOnce();
 		expect(result.status).toBe('success');
 	});
@@ -764,7 +780,15 @@ describe('first-sync', () => {
 			localOnly: [],
 			remoteOnly: ['conflict.md'],
 			identical: [],
-			conflicts: [{ path: 'conflict.md', action: 'conflict', local: 'added', remote: 'added' }],
+			conflicts: [{
+				path: 'conflict.md',
+				action: 'conflict',
+				local: 'added',
+				remote: 'added',
+				isBinary: false,
+				localSize: 0,
+				remoteSize: 0,
+			}],
 		};
 
 		vi.mocked(buildLocalInventory).mockResolvedValue(new Map());

--- a/tests/virtualized-list.test.ts
+++ b/tests/virtualized-list.test.ts
@@ -1,0 +1,130 @@
+import { describe, test, expect } from 'vitest';
+import { computeVirtualWindow } from '../src/ui/modals/virtualized-list';
+
+describe('computeVirtualWindow', () => {
+	test('empty itemCount returns empty window', () => {
+		const win = computeVirtualWindow({
+			scrollTop: 0,
+			viewportHeight: 100,
+			itemCount: 0,
+			getItemHeight: () => 50,
+		});
+		expect(win).toEqual({ startIndex: 0, endIndex: 0, totalHeight: 0, offsetY: 0 });
+	});
+
+	test('totalHeight sums all item heights', () => {
+		const win = computeVirtualWindow({
+			scrollTop: 0,
+			viewportHeight: 100,
+			itemCount: 5,
+			getItemHeight: () => 40,
+			overscan: 0,
+		});
+		expect(win.totalHeight).toBe(200);
+	});
+
+	test('scrollTop=0 with viewport=100, items 50px each → first 2 visible (no overscan)', () => {
+		const win = computeVirtualWindow({
+			scrollTop: 0,
+			viewportHeight: 100,
+			itemCount: 10,
+			getItemHeight: () => 50,
+			overscan: 0,
+		});
+		expect(win.startIndex).toBe(0);
+		expect(win.endIndex).toBe(2);
+		expect(win.offsetY).toBe(0);
+	});
+
+	test('overscan extends start and end by N items', () => {
+		const win = computeVirtualWindow({
+			scrollTop: 200,
+			viewportHeight: 100,
+			itemCount: 20,
+			getItemHeight: () => 50,
+			overscan: 2,
+		});
+		// scrollTop=200 → first visible is item 4 (200..250), last visible item 5 (250..300)
+		// With overscan=2: start=2, end=8
+		expect(win.startIndex).toBe(2);
+		expect(win.endIndex).toBe(8);
+		expect(win.offsetY).toBe(100);
+	});
+
+	test('overscan does not push start below 0 or end above itemCount', () => {
+		const winTop = computeVirtualWindow({
+			scrollTop: 0,
+			viewportHeight: 100,
+			itemCount: 10,
+			getItemHeight: () => 50,
+			overscan: 5,
+		});
+		expect(winTop.startIndex).toBe(0);
+		expect(winTop.offsetY).toBe(0);
+
+		const winBottom = computeVirtualWindow({
+			scrollTop: 450,
+			viewportHeight: 100,
+			itemCount: 10,
+			getItemHeight: () => 50,
+			overscan: 5,
+		});
+		expect(winBottom.endIndex).toBe(10);
+	});
+
+	test('variable item heights yield correct offsetY', () => {
+		const heights = [40, 60, 80, 100, 120];
+		const win = computeVirtualWindow({
+			scrollTop: 150,
+			viewportHeight: 100,
+			itemCount: heights.length,
+			getItemHeight: (i) => heights[i],
+			overscan: 0,
+		});
+		// Cumulative: [0, 40, 100, 180, 280, 400]
+		// scrollTop=150 → first item with bottom>150: index 2 (cumulative 100..180)
+		// bottom=250 → first item with top>=250: index 4 (top 280>=250 → wait, 280>=250)
+		// Actually: scan ends when cumulative >= bottom (250). cumulative reaches 280 at i=4.
+		expect(win.startIndex).toBe(2);
+		expect(win.offsetY).toBe(100);
+		expect(win.endIndex).toBe(4);
+		expect(win.totalHeight).toBe(400);
+	});
+
+	test('scrollTop beyond content returns empty window past the end', () => {
+		const win = computeVirtualWindow({
+			scrollTop: 1000,
+			viewportHeight: 100,
+			itemCount: 5,
+			getItemHeight: () => 50,
+		});
+		expect(win.startIndex).toBe(5);
+		expect(win.endIndex).toBe(5);
+		expect(win.totalHeight).toBe(250);
+		expect(win.offsetY).toBe(250);
+	});
+
+	test('default overscan of 3 is applied', () => {
+		const win = computeVirtualWindow({
+			scrollTop: 250,
+			viewportHeight: 100,
+			itemCount: 20,
+			getItemHeight: () => 50,
+		});
+		// Without overscan: start=5, end=7. With default overscan=3: start=2, end=10.
+		expect(win.startIndex).toBe(2);
+		expect(win.endIndex).toBe(10);
+	});
+
+	test('negative scrollTop is clamped to 0', () => {
+		const win = computeVirtualWindow({
+			scrollTop: -100,
+			viewportHeight: 100,
+			itemCount: 10,
+			getItemHeight: () => 50,
+			overscan: 0,
+		});
+		expect(win.startIndex).toBe(0);
+		expect(win.offsetY).toBe(0);
+	});
+});

--- a/tests/virtualized-list.test.ts
+++ b/tests/virtualized-list.test.ts
@@ -81,10 +81,9 @@ describe('computeVirtualWindow', () => {
 			getItemHeight: (i) => heights[i],
 			overscan: 0,
 		});
-		// Cumulative: [0, 40, 100, 180, 280, 400]
-		// scrollTop=150 → first item with bottom>150: index 2 (cumulative 100..180)
-		// bottom=250 → first item with top>=250: index 4 (top 280>=250 → wait, 280>=250)
-		// Actually: scan ends when cumulative >= bottom (250). cumulative reaches 280 at i=4.
+		// Cumulative tops: [0, 40, 100, 180, 280, 400]
+		// scrollTop=150 → first item whose bottom > 150 is index 2 (spans 100..180), offsetY=100
+		// bottom=250 → endIndex set when cumulative top >= 250, which happens at index 4 (top=280)
 		expect(win.startIndex).toBe(2);
 		expect(win.offsetY).toBe(100);
 		expect(win.endIndex).toBe(4);


### PR DESCRIPTION
## Summary
- Adds `ConflictResolutionModal` (§8.3) implementing `ConflictResolver`, replacing the always-ask placeholder error for mid-sync conflicts.
- Splits out `conflict-row` and `virtualized-list` as pure helpers so `FirstSyncModal` (#83) can reuse them.
- Enriches `ConflictItem` with `isBinary`, `localSize`, `remoteSize`, and `remoteBlobSha` so the modal can render text diffs and binary byte-count summaries without the engine's change-set maps.

Closes #82.

## Test plan
- [x] `npm test` (265 passed, including new `virtualized-list` and `conflict-row` unit tests under happy-dom)
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] Manual smoke: induce a real conflict against a test repo, resolve via the modal on desktop, confirm the resulting commit and vault state match selections
- [ ] Manual smoke: verify mobile layout (`Platform.isMobileApp` → `.jackdaw-mobile`) collapses to a single column on iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)