### PR TITLE
Wire conflict and first-sync modals into main.ts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Core modules (see §3 of the design spec for the ASCII diagram):
 - **`src/logger.ts`** — JSONL log to `.obsidian/plugins/<id>/sync.log`. Never logs PAT or file contents. Rotates at 1 MB. PAT scrubbed from all log lines via string replacement and a header regex.
 - **`src/settings.ts`** — `Settings` interface and `DEFAULT_SETTINGS` constant. Covers PAT, repo, conflict policy, per-file size limit, device name, include-obsidian-config, exclude patterns, verbose logging.
 - **`src/constants.ts`** — `PLUGIN_ID`, `SELF_EXCLUDED_PATHS` (hard-excludes `data.json`, `sync-state.json`, `.tmp`, `sync.log`, `.log.1`), and `BINARY_EXTENSIONS` set.
-- **`src/sync-engine-types.ts`** — Shared type contract for the sync engine. `LocalChange`, `RemoteChange`, `ClassifiedPath` (action: `'pull' | 'push' | 'conflict' | 'no-op' | 'state-refresh'`), `VaultAdapter`, `ConflictResolver`, `FirstSyncResolver`, `PolicyBasedResolver`, `SyncNeedsUIError`, `SyncStateInconsistencyError`.
+- **`src/sync-engine-types.ts`** — Shared type contract for the sync engine. `LocalChange`, `RemoteChange`, `ClassifiedPath` (action: `'pull' | 'push' | 'conflict' | 'no-op' | 'state-refresh'`), `VaultAdapter`, `ConflictResolver`, `FirstSyncResolver`, `PolicyBasedResolver`, `PolicyAwareConflictResolver`, `PolicyAwareFirstSyncResolver`, `SyncNeedsUIError`, `SyncStateInconsistencyError`. The `PolicyAware*` wrappers branch between modal and `PolicyBasedResolver` based on the live `conflictPolicy` setting; injected by `main.ts` so `SyncEngine` is policy-agnostic.
 - **`src/classifier.ts`** — Pure `classify()` function; full §5.5 4×4 matrix; §4.4 staleness detection (emits `'state-refresh'` when local blob SHA matches remote despite state mismatch).
 - **`src/file-scanner.ts`** — `FileScanner`; `.gitignore` parse + glob compiler; `.git/` directory-level hard-exclusion.
 - **`src/local-change-set.ts`** — `buildLocalChangeSet()`; delegates to `FileScanner`; computes SHA-256; identifies deletions from state.
@@ -76,7 +76,7 @@ Core modules (see §3 of the design spec for the ASCII diagram):
 - **`src/ui/settings-tab.ts`** — `JackdawSettingsTab`; Connection, Sync behavior, Inclusion, Diagnostics sections; `SyncLogModal`; `ResetSyncStateModal`.
 - **`src/ui/ribbon.ts`** — `RibbonIcon`; `setSyncing()` / `setIdle()` CSS class toggle on the ribbon element.
 - **`src/ui/status-bar.ts`** — `StatusBar`; `setIdle()`, `setSyncing()`, `setError()`; desktop-only.
-- **`src/main.ts`** — `JackdawPlugin` entry point. Instantiates and wires all components. `runSync()` with `isRunningSync` guard. `handleSyncResult()` delegates to `sync-notice.ts`. Android short-circuit. *(Conflict resolution modal and first-sync modal injected here in Phase 4.)*
+- **`src/main.ts`** — `JackdawPlugin` entry point. Instantiates and wires all components. Wraps `ConflictResolutionModal` and `FirstSyncModal` in `PolicyAwareConflictResolver` / `PolicyAwareFirstSyncResolver` so the live `conflictPolicy` setting decides between modal UI and `PolicyBasedResolver` on each sync. `runSync()` with `isRunningSync` guard. `handleSyncResult()` delegates to `sync-notice.ts`. Android short-circuit.
 
 ## Key design constraints
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,10 +11,10 @@ import { ObsidianStateAdapter } from './obsidian-state-adapter';
 import { StateStore } from './state-store';
 import { ObsidianVaultAdapter } from './obsidian-vault-adapter';
 import { SyncEngine } from './sync-engine';
-import type { SyncResult } from './sync-engine-types';
 import {
 	PolicyAwareConflictResolver,
 	PolicyAwareFirstSyncResolver,
+	type SyncResult,
 } from './sync-engine-types';
 import { formatSyncOutcome } from './sync-notice';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,10 @@ import { StateStore } from './state-store';
 import { ObsidianVaultAdapter } from './obsidian-vault-adapter';
 import { SyncEngine } from './sync-engine';
 import type { SyncResult } from './sync-engine-types';
+import {
+	PolicyAwareConflictResolver,
+	PolicyAwareFirstSyncResolver,
+} from './sync-engine-types';
 import { formatSyncOutcome } from './sync-notice';
 
 export default class JackdawPlugin extends Plugin {
@@ -61,6 +65,14 @@ export default class JackdawPlugin extends Plugin {
 		});
 		const conflictModal = new ConflictResolutionModal(this.app, vault, client, repoCoords);
 		const firstSyncModal = new FirstSyncModal(this.app, vault, client, repoCoords);
+		const conflictResolver = new PolicyAwareConflictResolver(
+			() => this.settings.conflictPolicy,
+			conflictModal,
+		);
+		const firstSyncResolver = new PolicyAwareFirstSyncResolver(
+			() => this.settings.conflictPolicy,
+			firstSyncModal,
+		);
 
 		this.engine = new SyncEngine(
 			vault,
@@ -68,8 +80,8 @@ export default class JackdawPlugin extends Plugin {
 			stateStore,
 			logger,
 			() => this.settings,
-			conflictModal,
-			firstSyncModal,
+			conflictResolver,
+			firstSyncResolver,
 		);
 
 		if (!Platform.isMobileApp) {

--- a/src/sync-engine-types.ts
+++ b/src/sync-engine-types.ts
@@ -121,3 +121,33 @@ export class PolicyBasedResolver implements ConflictResolver, FirstSyncResolver 
 		return Promise.resolve(result);
 	}
 }
+
+export class PolicyAwareConflictResolver implements ConflictResolver {
+	constructor(
+		private readonly getPolicy: () => ConflictPolicy,
+		private readonly modal: ConflictResolver,
+	) {}
+
+	resolve(conflicts: ConflictItem[]): Promise<Map<string, ConflictResolution> | 'cancel'> {
+		const policy = this.getPolicy();
+		if (policy === 'always-ask') {
+			return this.modal.resolve(conflicts);
+		}
+		return new PolicyBasedResolver(() => policy).resolve(conflicts);
+	}
+}
+
+export class PolicyAwareFirstSyncResolver implements FirstSyncResolver {
+	constructor(
+		private readonly getPolicy: () => ConflictPolicy,
+		private readonly modal: FirstSyncResolver,
+	) {}
+
+	resolve(summary: FirstSyncSummary): Promise<Map<string, ConflictResolution> | 'cancel'> {
+		const policy = this.getPolicy();
+		if (policy === 'always-ask') {
+			return this.modal.resolve(summary);
+		}
+		return new PolicyBasedResolver(() => policy).resolve(summary);
+	}
+}

--- a/src/sync-engine.ts
+++ b/src/sync-engine.ts
@@ -18,7 +18,6 @@ import type {
 	ConflictItem,
 	ConflictResolution,
 } from './sync-engine-types';
-import { PolicyBasedResolver } from './sync-engine-types';
 
 const MAX_FF_RETRIES = 2;
 
@@ -87,7 +86,6 @@ export class SyncEngine {
 	): Promise<SyncResult> {
 		const { owner, repo, branch } = settings;
 		let fastForwardRetries = 0;
-		const policyResolver = new PolicyBasedResolver(() => settings.conflictPolicy);
 
 		const report: SyncReport = {
 			filesAdded: 0,
@@ -157,15 +155,11 @@ export class SyncEngine {
 			let conflictResolutions = new Map<string, ConflictResolution>();
 
 			if (conflictItems.length > 0) {
-				if (settings.conflictPolicy !== 'always-ask') {
-					conflictResolutions = (await policyResolver.resolve(conflictItems)) as Map<string, ConflictResolution>;
-				} else {
-					const result = await this.conflicts.resolve(conflictItems);
-					if (result === 'cancel') {
-						return { status: 'cancelled' };
-					}
-					conflictResolutions = result;
+				const result = await this.conflicts.resolve(conflictItems);
+				if (result === 'cancel') {
+					return { status: 'cancelled' };
 				}
+				conflictResolutions = result;
 				report.conflictsResolved = conflictResolutions.size;
 			}
 

--- a/src/sync-notice.ts
+++ b/src/sync-notice.ts
@@ -9,10 +9,6 @@ export interface SyncNoticeOutcome {
 	statusBar: StatusBarUpdate;
 }
 
-const SYNC_NEEDS_UI_MESSAGE =
-	"Conflict resolution UI is not yet available. Choose 'Prefer local' or 'Prefer remote' in settings, or wait for the next release.";
-const SYNC_NEEDS_UI_STATUS = 'Conflict — set conflict policy';
-
 export function formatSyncOutcome(
 	result: SyncResult,
 	now: () => string,
@@ -45,12 +41,6 @@ export function formatSyncOutcome(
 				statusBar: { kind: 'idle', lastSyncAt: lastKnownSyncAt },
 			};
 		case 'error':
-			if (result.error.name === 'SyncNeedsUIError') {
-				return {
-					toasts: [SYNC_NEEDS_UI_MESSAGE],
-					statusBar: { kind: 'error', message: SYNC_NEEDS_UI_STATUS },
-				};
-			}
 			if (result.error.name === 'GHEmptyRepoError') {
 				return {
 					toasts: [result.error.message],

--- a/tests/policy-aware-resolver.test.ts
+++ b/tests/policy-aware-resolver.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test, vi } from 'vitest';
+import {
+	PolicyAwareConflictResolver,
+	PolicyAwareFirstSyncResolver,
+} from '../src/sync-engine-types';
+import type {
+	ConflictItem,
+	ConflictResolver,
+	FirstSyncResolver,
+	FirstSyncSummary,
+} from '../src/sync-engine-types';
+import type { ConflictPolicy } from '../src/settings';
+
+function makeConflicts(): ConflictItem[] {
+	return [
+		{
+			path: 'a.md',
+			action: 'conflict',
+			local: 'modified',
+			remote: 'modified',
+			isBinary: false,
+			localSize: 0,
+			remoteSize: 0,
+		},
+	];
+}
+
+function makeSummary(conflicts: ConflictItem[] = makeConflicts()): FirstSyncSummary {
+	return {
+		localOnly: [],
+		remoteOnly: [],
+		identical: [],
+		conflicts,
+	};
+}
+
+describe('PolicyAwareConflictResolver', () => {
+	test('always-ask delegates to the modal', async () => {
+		const modal: ConflictResolver = { resolve: vi.fn().mockResolvedValue('cancel') };
+		const wrapper = new PolicyAwareConflictResolver(() => 'always-ask', modal);
+
+		const result = await wrapper.resolve(makeConflicts());
+
+		expect(modal.resolve).toHaveBeenCalledOnce();
+		expect(result).toBe('cancel');
+	});
+
+	test('always-prefer-local resolves to keep-local without invoking the modal', async () => {
+		const modal: ConflictResolver = { resolve: vi.fn() };
+		const wrapper = new PolicyAwareConflictResolver(() => 'always-prefer-local', modal);
+
+		const result = (await wrapper.resolve(makeConflicts())) as Map<string, 'keep-local' | 'keep-remote'>;
+
+		expect(modal.resolve).not.toHaveBeenCalled();
+		expect(result.get('a.md')).toBe('keep-local');
+	});
+
+	test('always-prefer-remote resolves to keep-remote without invoking the modal', async () => {
+		const modal: ConflictResolver = { resolve: vi.fn() };
+		const wrapper = new PolicyAwareConflictResolver(() => 'always-prefer-remote', modal);
+
+		const result = (await wrapper.resolve(makeConflicts())) as Map<string, 'keep-local' | 'keep-remote'>;
+
+		expect(modal.resolve).not.toHaveBeenCalled();
+		expect(result.get('a.md')).toBe('keep-remote');
+	});
+
+	test('reads policy fresh on each resolve — value change after construction takes effect', async () => {
+		const modal: ConflictResolver = { resolve: vi.fn().mockResolvedValue(new Map([['a.md', 'keep-remote']])) };
+		let policy: ConflictPolicy = 'always-prefer-local';
+		const wrapper = new PolicyAwareConflictResolver(() => policy, modal);
+
+		const first = (await wrapper.resolve(makeConflicts())) as Map<string, 'keep-local' | 'keep-remote'>;
+		expect(first.get('a.md')).toBe('keep-local');
+		expect(modal.resolve).not.toHaveBeenCalled();
+
+		policy = 'always-ask';
+
+		await wrapper.resolve(makeConflicts());
+		expect(modal.resolve).toHaveBeenCalledOnce();
+	});
+});
+
+describe('PolicyAwareFirstSyncResolver', () => {
+	test('always-ask delegates to the modal', async () => {
+		const modal: FirstSyncResolver = { resolve: vi.fn().mockResolvedValue('cancel') };
+		const wrapper = new PolicyAwareFirstSyncResolver(() => 'always-ask', modal);
+
+		const result = await wrapper.resolve(makeSummary());
+
+		expect(modal.resolve).toHaveBeenCalledOnce();
+		expect(result).toBe('cancel');
+	});
+
+	test('always-prefer-local auto-resolves all conflicts to keep-local', async () => {
+		const modal: FirstSyncResolver = { resolve: vi.fn() };
+		const wrapper = new PolicyAwareFirstSyncResolver(() => 'always-prefer-local', modal);
+
+		const result = (await wrapper.resolve(makeSummary())) as Map<string, 'keep-local' | 'keep-remote'>;
+
+		expect(modal.resolve).not.toHaveBeenCalled();
+		expect(result.get('a.md')).toBe('keep-local');
+	});
+
+	test('always-prefer-remote auto-resolves all conflicts to keep-remote', async () => {
+		const modal: FirstSyncResolver = { resolve: vi.fn() };
+		const wrapper = new PolicyAwareFirstSyncResolver(() => 'always-prefer-remote', modal);
+
+		const result = (await wrapper.resolve(makeSummary())) as Map<string, 'keep-local' | 'keep-remote'>;
+
+		expect(modal.resolve).not.toHaveBeenCalled();
+		expect(result.get('a.md')).toBe('keep-remote');
+	});
+});

--- a/tests/sync-engine.test.ts
+++ b/tests/sync-engine.test.ts
@@ -405,12 +405,11 @@ describe('normal sync', () => {
 		}
 	});
 
-	test('conflicts with always-prefer-local → ConflictResolver not called, conflict pushed', async () => {
+	test('conflict resolved keep-local → applyPush called, conflictsResolved counted', async () => {
 		const state = makeState();
 		const updatedState = makeState({ lastSyncCommitSha: 'new-commit' });
 		const { engine, conflicts } = makeEngine({
 			stateStore: makeStateStore(state),
-			settings: makeSettings({ conflictPolicy: 'always-prefer-local' }),
 		});
 
 		const conflictPath = makeClassified('conflict.md', 'conflict', 'modified', 'modified');
@@ -421,11 +420,12 @@ describe('normal sync', () => {
 			new Map([['conflict.md', makeRemoteChange('conflict.md', 'modified')]]),
 		);
 		vi.mocked(classify).mockResolvedValue([conflictPath]);
+		conflicts.resolve.mockResolvedValue(new Map([['conflict.md', 'keep-local']]));
 		vi.mocked(applyPush).mockResolvedValue({ newCommitSha: 'new-commit', updatedState });
 
 		const result = await engine.sync();
 
-		expect(conflicts.resolve).not.toHaveBeenCalled();
+		expect(conflicts.resolve).toHaveBeenCalledOnce();
 		expect(applyPush).toHaveBeenCalledOnce();
 		expect(result.status).toBe('success');
 		if (result.status === 'success') {
@@ -433,12 +433,11 @@ describe('normal sync', () => {
 		}
 	});
 
-	test('conflicts with always-prefer-remote → ConflictResolver not called, conflict pulled', async () => {
+	test('conflict resolved keep-remote → applyPull called, conflictsResolved counted', async () => {
 		const state = makeState();
 		const updatedState = makeState();
 		const { engine, conflicts } = makeEngine({
 			stateStore: makeStateStore(state),
-			settings: makeSettings({ conflictPolicy: 'always-prefer-remote' }),
 		});
 
 		const conflictPath = makeClassified('conflict.md', 'conflict', 'modified', 'modified');
@@ -449,11 +448,12 @@ describe('normal sync', () => {
 			new Map([['conflict.md', makeRemoteChange('conflict.md', 'modified')]]),
 		);
 		vi.mocked(classify).mockResolvedValue([conflictPath]);
+		conflicts.resolve.mockResolvedValue(new Map([['conflict.md', 'keep-remote']]));
 		vi.mocked(applyPull).mockResolvedValue({ updatedState, skipped: [] });
 
 		const result = await engine.sync();
 
-		expect(conflicts.resolve).not.toHaveBeenCalled();
+		expect(conflicts.resolve).toHaveBeenCalledOnce();
 		expect(applyPull).toHaveBeenCalledOnce();
 		expect(result.status).toBe('success');
 		if (result.status === 'success') {
@@ -614,9 +614,8 @@ describe('GHFastForwardError retry', () => {
 	test('conflictsResolved not double-counted across retries', async () => {
 		const state = makeState();
 		const updatedState = makeState({ lastSyncCommitSha: 'new-commit' });
-		const { engine } = makeEngine({
+		const { engine, conflicts } = makeEngine({
 			stateStore: makeStateStore(state),
-			settings: makeSettings({ conflictPolicy: 'always-prefer-local' }),
 		});
 
 		const conflictPath = makeClassified('conflict.md', 'conflict', 'modified', 'modified');
@@ -627,6 +626,7 @@ describe('GHFastForwardError retry', () => {
 			new Map([['conflict.md', makeRemoteChange('conflict.md', 'modified')]]),
 		);
 		vi.mocked(classify).mockResolvedValue([conflictPath]);
+		conflicts.resolve.mockResolvedValue(new Map([['conflict.md', 'keep-local']]));
 		vi.mocked(applyPush)
 			.mockRejectedValueOnce(new GHFastForwardError('ff'))
 			.mockResolvedValue({ newCommitSha: 'new-commit', updatedState });

--- a/tests/sync-notice.test.ts
+++ b/tests/sync-notice.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'vitest';
 import { formatSyncOutcome } from '../src/sync-notice';
-import { SyncNeedsUIError } from '../src/sync-engine-types';
 import type { SyncReport, SyncResult } from '../src/sync-engine-types';
 
 const NOW = '2026-04-30T12:00:00.000Z';
@@ -90,19 +89,6 @@ describe('formatSyncOutcome', () => {
 	test('cancelled with no last known sync time leaves status bar in never-synced state', () => {
 		const outcome = formatSyncOutcome({ status: 'cancelled' }, now, null);
 		expect(outcome.statusBar).toEqual({ kind: 'idle', lastSyncAt: null });
-	});
-
-	test('SyncNeedsUIError produces dedicated message and dedicated status bar text', () => {
-		const result: SyncResult = { status: 'error', error: new SyncNeedsUIError() };
-		const outcome = formatSyncOutcome(result, now, null);
-
-		expect(outcome.toasts).toEqual([
-			"Conflict resolution UI is not yet available. Choose 'Prefer local' or 'Prefer remote' in settings, or wait for the next release.",
-		]);
-		expect(outcome.statusBar).toEqual({
-			kind: 'error',
-			message: 'Conflict — set conflict policy',
-		});
 	});
 
 	test('GHEmptyRepoError produces actionable message and short status bar text', () => {


### PR DESCRIPTION
## Summary
- Adds `PolicyAwareConflictResolver` and `PolicyAwareFirstSyncResolver` wrappers in `sync-engine-types.ts` that branch between modal UI and `PolicyBasedResolver` based on the live `conflictPolicy` setting.
- `main.ts` wraps the conflict and first-sync modals with these resolvers before injecting into `SyncEngine`, so policy changes take effect on the next sync without re-instantiating the engine.
- Simplifies `SyncEngine.runNormalSync` — the inline `always-ask` vs. `PolicyBasedResolver` branching is gone; the engine is now policy-agnostic.
- Removes the `SyncNeedsUIError` placeholder branch from `sync-notice.ts`; with the modals wired up that error is no longer reachable on the always-ask path.

Closes #84

## Test plan
- [x] `npm test` — 271 tests pass (includes new `tests/policy-aware-resolver.test.ts` with 7 tests, and updated `tests/sync-engine.test.ts` / `tests/sync-notice.test.ts`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run build` produces `main.js`
- [ ] Manual desktop smoke: with default `always-ask`, induce a conflict and resolve via the modal
- [ ] Manual desktop smoke: with default `always-ask`, fresh state file → first-sync modal works
- [ ] Manual desktop smoke: switch policy to `always-prefer-local` mid-session, sync — confirm modal does not appear and conflicts auto-resolve
- [ ] Verify PAT does not appear in `sync.log` after a conflict-resolution sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)