### PR TITLE
Improve issue/PR workflow instructions

### DIFF
--- a/.claude/commands/review-fix.md
+++ b/.claude/commands/review-fix.md
@@ -1,16 +1,18 @@
 Run a full PR review using the `review` skill, then immediately address every issue it finds.
 
 Steps:
-1. Invoke the `review` skill to review the current branch's changes.
-2. Read the review output carefully.
-3. For each issue identified (bugs, style violations, missing tests, architectural concerns, etc.), implement a fix directly in the codebase.
-4. After all fixes are applied, commit the changes with a clear message summarizing what was addressed.
-5. Push the commit to the current branch.
-6. Check whether a PR already exists for this branch (use the GitHub MCP tools or `gh pr view`).
-   - If no PR exists, create one for the current branch following the repo's PR conventions (short title, body with summary + test plan, `Closes #N` / `Fixes #N` for any issue this PR resolves).
-   - If a PR exists, verify and update it as needed:
-     - Title is short and descriptive with no issue references (e.g. no `(#N)` suffix) — update if needed.
-     - Body includes `Closes #N` (or `Fixes #N`) for any issue this PR resolves — add if missing.
-     - Body has a meaningful summary and test plan — add if the body is bare or missing.
-     Update the PR via the GitHub MCP tools if any of the above are missing.
+1. Ensure a PR exists for the current branch **before** running the review, so `review` can target the PR rather than diffing the branch against `main`.
+   - Push the current branch to the remote if it has unpushed commits or no upstream.
+   - Check whether a PR already exists (use the GitHub MCP tools or `gh pr view`).
+     - If no PR exists, create one following the repo's PR conventions (short title, body with summary + test plan, `Closes #N` / `Fixes #N` for any issue this PR resolves).
+     - If a PR exists, verify and update it as needed:
+       - Title is short and descriptive with no issue references (e.g. no `(#N)` suffix) — update if needed.
+       - Body includes `Closes #N` (or `Fixes #N`) for any issue this PR resolves — add if missing.
+       - Body has a meaningful summary and test plan — add if the body is bare or missing.
+       Update the PR via the GitHub MCP tools if any of the above are missing.
+2. Invoke the `review` skill to review the PR.
+3. Read the review output carefully.
+4. For each issue identified (bugs, style violations, missing tests, architectural concerns, etc.), implement a fix directly in the codebase.
+5. After all fixes are applied, commit the changes with a clear message summarizing what was addressed.
+6. Push the commit to the current branch.
 7. Summarize what was fixed and note anything that was intentionally left alone (e.g. subjective suggestions or out-of-scope changes).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,10 +41,11 @@ If the session opens with a message that is solely an issue number (e.g. `#40` o
 
 1. Fetch the issue from `jimcasey/jackdaw` using the GitHub MCP tools.
 2. Read the issue body and any linked design-spec sections to understand the requirements.
-3. Create (or check out) the appropriate feature branch following the repo's branch-naming convention.
-4. Implement the issue — writing code, tests, and any doc updates required.
-5. Commit and push to the feature branch.
-6. Do **not** open a pull request unless the user explicitly asks for one.
+3. Update local `main` from the remote (`git checkout main && git pull --ff-only origin main`) so the new branch starts from the latest base. If `main` is already checked out, just pull.
+4. Create (or check out) the appropriate feature branch following the repo's branch-naming convention, branching from the freshly-updated `main`.
+5. Implement the issue — writing code, tests, and any doc updates required.
+6. Commit and push to the feature branch.
+7. Open a pull request following the repo's PR conventions (short title, body with summary + test plan, `Closes #N` or `Fixes #N` in the body so the issue auto-closes on merge).
 
 ## Pull requests
 


### PR DESCRIPTION
## Summary
- CLAUDE.md issue shorthand: pull latest `main` before branching, and open a PR when implementation is complete (replaces the previous "do not open a PR" rule).
- `/review-fix`: move the PR existence check to the start of the flow so the `review` skill targets the PR rather than diffing the branch against `main`.

## Test plan
- [ ] Trigger the issue-shorthand flow in a future session and confirm the new branch is rooted on the latest `main` and a PR is opened at the end.
- [ ] Run `/review-fix` on a branch without a PR and verify the PR is created up front before the `review` skill runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)