### PR TITLE
Fix conflict modal diff rendering

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -116,13 +116,14 @@
   grid-template-columns: 1fr 1fr;
   font-family: var(--font-monospace);
   font-size: 0.85em;
-  white-space: pre-wrap;
-  word-break: break-word;
+  white-space: pre;
+  overflow-x: auto;
 }
 
 .jackdaw-diff-line {
   padding: 0 0.5em;
   line-height: 20px;
+  min-height: 20px;
 }
 
 .jackdaw-diff-context {
@@ -132,14 +133,14 @@
 
 .jackdaw-diff-remove {
   grid-column: 1 / 2;
-  background: var(--background-modifier-error);
-  color: var(--text-error);
+  background: rgba(var(--color-red-rgb), 0.15);
+  color: var(--text-normal);
 }
 
 .jackdaw-diff-add {
   grid-column: 2 / 3;
-  background: var(--background-modifier-success);
-  color: var(--text-success);
+  background: rgba(var(--color-green-rgb), 0.15);
+  color: var(--text-normal);
 }
 
 .jackdaw-mobile .jackdaw-diff {


### PR DESCRIPTION
## Summary
- Restores readable text in expanded conflict rows by replacing same-as-background `--text-error`/`--text-success` colors with tinted backgrounds + `--text-normal`.
- Adds `min-height: 20px` to diff lines so blank source lines occupy a full line of vertical space instead of collapsing to 0.
- Switches the diff grid to `white-space: pre; overflow-x: auto` so the virtualized list's `lines.length * 20px` row-height calculation stays accurate (long lines now scroll horizontally instead of wrapping).

Closes #110

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 271 tests pass
- [x] `npm run build` succeeds
- [ ] Manual: reproduce the screenshot scenario from #110 and verify the differing line is readable in each colored cell, blank lines occupy a full line of vertical space, and the trailing context line is visible
- [ ] Manual: a conflict with a single very long line (200+ chars) — verify horizontal scroll works and rows below don't overlap
- [ ] Manual: a conflict with many blank lines in the middle — verify they all render with consistent height
- [ ] Manual: re-test on Obsidian iOS where the modal switches to stacked unified layout (`.jackdaw-mobile`)