### PR TITLE
Fix conflict modal diff wrapping on mobile

### DIFF
--- a/src/ui/modals/conflict-resolution-modal.ts
+++ b/src/ui/modals/conflict-resolution-modal.ts
@@ -31,12 +31,14 @@ export class ConflictResolutionModal extends Modal implements ConflictResolver {
 	private readonly expanded = new Map<string, boolean>();
 	private readonly contentCache = new Map<string, ConflictRowContentState>();
 	private readonly rowControllers = new Map<string, ConflictRowController>();
+	private readonly measuredHeights = new Map<string, number>();
 
 	private listEl: HTMLElement | null = null;
 	private spacerEl: HTMLElement | null = null;
 	private applyBtn: HTMLButtonElement | null = null;
 	private resolvePromise: ((value: Map<string, ConflictResolution> | 'cancel') => void) | null = null;
 	private settled = false;
+	private rerenderScheduled = false;
 
 	constructor(app: App, vault: VaultAdapter, client: GitHubClient, getRepoCoords: () => RepoCoords) {
 		super(app);
@@ -52,6 +54,7 @@ export class ConflictResolutionModal extends Modal implements ConflictResolver {
 		this.expanded.clear();
 		this.contentCache.clear();
 		this.rowControllers.clear();
+		this.measuredHeights.clear();
 
 		return new Promise((resolve) => {
 			this.resolvePromise = resolve;
@@ -99,7 +102,11 @@ export class ConflictResolutionModal extends Modal implements ConflictResolver {
 		}
 		this.contentEl.empty();
 		this.modalEl.classList.remove('jackdaw-conflict-modal', 'jackdaw-mobile');
+		for (const controller of this.rowControllers.values()) {
+			controller.disconnect();
+		}
 		this.rowControllers.clear();
+		this.measuredHeights.clear();
 		this.listEl = null;
 		this.spacerEl = null;
 		this.applyBtn = null;
@@ -116,6 +123,8 @@ export class ConflictResolutionModal extends Modal implements ConflictResolver {
 
 	private getRowHeight(index: number): number {
 		const item = this.conflicts[index];
+		const measured = this.measuredHeights.get(item.path);
+		if (measured !== undefined && measured > 0) return measured;
 		if (!this.expanded.get(item.path)) {
 			return COLLAPSED_ROW_HEIGHT;
 		}
@@ -124,6 +133,18 @@ export class ConflictResolutionModal extends Modal implements ConflictResolver {
 			return COLLAPSED_ROW_HEIGHT + FIXED_BLOCK_HEIGHT_PX;
 		}
 		return COLLAPSED_ROW_HEIGHT + EXPANDED_PADDING_PX + cached.lines.length * LINE_HEIGHT_PX;
+	}
+
+	private handleHeightChange(path: string, height: number): void {
+		if (height <= 0) return;
+		if (this.measuredHeights.get(path) === height) return;
+		this.measuredHeights.set(path, height);
+		if (this.rerenderScheduled) return;
+		this.rerenderScheduled = true;
+		requestAnimationFrame(() => {
+			this.rerenderScheduled = false;
+			this.renderVisible();
+		});
 	}
 
 	private renderVisible(): void {
@@ -153,6 +174,7 @@ export class ConflictResolutionModal extends Modal implements ConflictResolver {
 					initialExpanded: this.expanded.get(item.path) ?? false,
 					onSelect: (resolution) => this.handleSelect(item.path, resolution),
 					onToggle: () => this.handleToggle(item),
+					onHeightChange: (height) => this.handleHeightChange(item.path, height),
 				});
 				controller.el.style.position = 'absolute';
 				controller.el.style.left = '0';
@@ -168,6 +190,7 @@ export class ConflictResolutionModal extends Modal implements ConflictResolver {
 
 		for (const [path, controller] of this.rowControllers) {
 			if (!visiblePaths.has(path)) {
+				controller.disconnect();
 				controller.el.remove();
 				this.rowControllers.delete(path);
 			}
@@ -186,6 +209,7 @@ export class ConflictResolutionModal extends Modal implements ConflictResolver {
 		const wasExpanded = this.expanded.get(path) ?? false;
 		const nowExpanded = !wasExpanded;
 		this.expanded.set(path, nowExpanded);
+		this.measuredHeights.delete(path);
 		const controller = this.rowControllers.get(path);
 		controller?.setExpanded(nowExpanded);
 

--- a/src/ui/modals/conflict-resolution-modal.ts
+++ b/src/ui/modals/conflict-resolution-modal.ts
@@ -107,6 +107,7 @@ export class ConflictResolutionModal extends Modal implements ConflictResolver {
 		}
 		this.rowControllers.clear();
 		this.measuredHeights.clear();
+		this.rerenderScheduled = false;
 		this.listEl = null;
 		this.spacerEl = null;
 		this.applyBtn = null;

--- a/src/ui/modals/conflict-row.ts
+++ b/src/ui/modals/conflict-row.ts
@@ -13,6 +13,7 @@ export interface ConflictRowOptions {
 	initialExpanded: boolean;
 	onSelect: (resolution: ConflictResolution) => void;
 	onToggle: () => void;
+	onHeightChange?: (height: number) => void;
 }
 
 export interface ConflictRowController {
@@ -20,6 +21,7 @@ export interface ConflictRowController {
 	setResolution(resolution: ConflictResolution | null): void;
 	setExpanded(expanded: boolean): void;
 	setContent(content: ConflictRowContentState): void;
+	disconnect(): void;
 }
 
 export function createConflictRow(opts: ConflictRowOptions): ConflictRowController {
@@ -112,5 +114,17 @@ export function createConflictRow(opts: ConflictRowOptions): ConflictRowControll
 	setResolution(opts.initialResolution);
 	setExpanded(opts.initialExpanded);
 
-	return { el: root, setResolution, setExpanded, setContent };
+	let observer: ResizeObserver | null = null;
+	const onHeightChange = opts.onHeightChange;
+	if (onHeightChange && typeof ResizeObserver !== 'undefined') {
+		observer = new ResizeObserver(() => onHeightChange(root.offsetHeight));
+		observer.observe(root);
+	}
+
+	function disconnect(): void {
+		observer?.disconnect();
+		observer = null;
+	}
+
+	return { el: root, setResolution, setExpanded, setContent, disconnect };
 }

--- a/src/ui/modals/conflict-row.ts
+++ b/src/ui/modals/conflict-row.ts
@@ -116,7 +116,7 @@ export function createConflictRow(opts: ConflictRowOptions): ConflictRowControll
 
 	let observer: ResizeObserver | null = null;
 	const onHeightChange = opts.onHeightChange;
-	if (onHeightChange && typeof ResizeObserver !== 'undefined') {
+	if (onHeightChange) {
 		observer = new ResizeObserver(() => onHeightChange(root.offsetHeight));
 		observer.observe(root);
 	}

--- a/src/ui/modals/first-sync-modal.ts
+++ b/src/ui/modals/first-sync-modal.ts
@@ -122,6 +122,7 @@ export class FirstSyncModal extends Modal implements FirstSyncResolver {
 		}
 		this.rowControllers.clear();
 		this.measuredHeights.clear();
+		this.rerenderScheduled = false;
 		this.listEl = null;
 		this.spacerEl = null;
 		this.applyBtn = null;

--- a/src/ui/modals/first-sync-modal.ts
+++ b/src/ui/modals/first-sync-modal.ts
@@ -32,6 +32,7 @@ export class FirstSyncModal extends Modal implements FirstSyncResolver {
 	private readonly expanded = new Map<string, boolean>();
 	private readonly contentCache = new Map<string, ConflictRowContentState>();
 	private readonly rowControllers = new Map<string, ConflictRowController>();
+	private readonly measuredHeights = new Map<string, number>();
 
 	private listEl: HTMLElement | null = null;
 	private spacerEl: HTMLElement | null = null;
@@ -39,6 +40,7 @@ export class FirstSyncModal extends Modal implements FirstSyncResolver {
 	private confirmCheckbox: HTMLInputElement | null = null;
 	private resolvePromise: ((value: Map<string, ConflictResolution> | 'cancel') => void) | null = null;
 	private settled = false;
+	private rerenderScheduled = false;
 
 	constructor(app: App, vault: VaultAdapter, client: GitHubClient, getRepoCoords: () => RepoCoords) {
 		super(app);
@@ -54,6 +56,7 @@ export class FirstSyncModal extends Modal implements FirstSyncResolver {
 		this.expanded.clear();
 		this.contentCache.clear();
 		this.rowControllers.clear();
+		this.measuredHeights.clear();
 
 		return new Promise((resolve) => {
 			this.resolvePromise = resolve;
@@ -114,7 +117,11 @@ export class FirstSyncModal extends Modal implements FirstSyncResolver {
 		}
 		this.contentEl.empty();
 		this.modalEl.classList.remove('jackdaw-conflict-modal', 'jackdaw-first-sync-modal', 'jackdaw-mobile');
+		for (const controller of this.rowControllers.values()) {
+			controller.disconnect();
+		}
 		this.rowControllers.clear();
+		this.measuredHeights.clear();
 		this.listEl = null;
 		this.spacerEl = null;
 		this.applyBtn = null;
@@ -147,6 +154,8 @@ export class FirstSyncModal extends Modal implements FirstSyncResolver {
 
 	private getRowHeight(index: number): number {
 		const item = this.summary.conflicts[index];
+		const measured = this.measuredHeights.get(item.path);
+		if (measured !== undefined && measured > 0) return measured;
 		if (!this.expanded.get(item.path)) {
 			return COLLAPSED_ROW_HEIGHT;
 		}
@@ -155,6 +164,18 @@ export class FirstSyncModal extends Modal implements FirstSyncResolver {
 			return COLLAPSED_ROW_HEIGHT + FIXED_BLOCK_HEIGHT_PX;
 		}
 		return COLLAPSED_ROW_HEIGHT + EXPANDED_PADDING_PX + cached.lines.length * LINE_HEIGHT_PX;
+	}
+
+	private handleHeightChange(path: string, height: number): void {
+		if (height <= 0) return;
+		if (this.measuredHeights.get(path) === height) return;
+		this.measuredHeights.set(path, height);
+		if (this.rerenderScheduled) return;
+		this.rerenderScheduled = true;
+		requestAnimationFrame(() => {
+			this.rerenderScheduled = false;
+			this.renderVisible();
+		});
 	}
 
 	private renderVisible(): void {
@@ -185,6 +206,7 @@ export class FirstSyncModal extends Modal implements FirstSyncResolver {
 					initialExpanded: this.expanded.get(item.path) ?? false,
 					onSelect: (resolution) => this.handleSelect(item.path, resolution),
 					onToggle: () => this.handleToggle(item),
+					onHeightChange: (height) => this.handleHeightChange(item.path, height),
 				});
 				controller.el.style.position = 'absolute';
 				controller.el.style.left = '0';
@@ -200,6 +222,7 @@ export class FirstSyncModal extends Modal implements FirstSyncResolver {
 
 		for (const [path, controller] of this.rowControllers) {
 			if (!visiblePaths.has(path)) {
+				controller.disconnect();
 				controller.el.remove();
 				this.rowControllers.delete(path);
 			}
@@ -218,6 +241,7 @@ export class FirstSyncModal extends Modal implements FirstSyncResolver {
 		const wasExpanded = this.expanded.get(path) ?? false;
 		const nowExpanded = !wasExpanded;
 		this.expanded.set(path, nowExpanded);
+		this.measuredHeights.delete(path);
 		const controller = this.rowControllers.get(path);
 		controller?.setExpanded(nowExpanded);
 

--- a/styles.css
+++ b/styles.css
@@ -145,6 +145,9 @@
 
 .jackdaw-mobile .jackdaw-diff {
   display: block;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: visible;
 }
 
 .jackdaw-mobile .jackdaw-diff-line {

--- a/tests/conflict-row.test.ts
+++ b/tests/conflict-row.test.ts
@@ -195,6 +195,29 @@ describe('createConflictRow', () => {
 		expect(lineEls[2].textContent).toBe('new');
 	});
 
+	test('disconnect() can be called safely whether or not onHeightChange was passed', () => {
+		const rowWithoutObserver = createConflictRow({
+			item: makeItem(),
+			initialResolution: null,
+			initialExpanded: false,
+			onSelect: () => {},
+			onToggle: () => {},
+		});
+		expect(() => rowWithoutObserver.disconnect()).not.toThrow();
+		expect(() => rowWithoutObserver.disconnect()).not.toThrow();
+
+		const onHeightChange = vi.fn();
+		const rowWithObserver = createConflictRow({
+			item: makeItem({ path: 'notes/bar.md' }),
+			initialResolution: null,
+			initialExpanded: false,
+			onSelect: () => {},
+			onToggle: () => {},
+			onHeightChange,
+		});
+		expect(() => rowWithObserver.disconnect()).not.toThrow();
+	});
+
 	test('setContent replaces previous content rather than appending', () => {
 		const row = createConflictRow({
 			item: makeItem(),

--- a/tests/conflict-row.test.ts
+++ b/tests/conflict-row.test.ts
@@ -195,27 +195,95 @@ describe('createConflictRow', () => {
 		expect(lineEls[2].textContent).toBe('new');
 	});
 
-	test('disconnect() can be called safely whether or not onHeightChange was passed', () => {
-		const rowWithoutObserver = createConflictRow({
-			item: makeItem(),
-			initialResolution: null,
-			initialExpanded: false,
-			onSelect: () => {},
-			onToggle: () => {},
-		});
-		expect(() => rowWithoutObserver.disconnect()).not.toThrow();
-		expect(() => rowWithoutObserver.disconnect()).not.toThrow();
+	test('no ResizeObserver is created when onHeightChange is omitted; disconnect is still safe', () => {
+		const instances: FakeObserver[] = [];
+		class FakeObserver {
+			observe = vi.fn();
+			unobserve = vi.fn();
+			disconnect = vi.fn();
+			constructor(public cb: ResizeObserverCallback) {
+				instances.push(this);
+			}
+		}
+		const original = globalThis.ResizeObserver;
+		globalThis.ResizeObserver = FakeObserver as unknown as typeof ResizeObserver;
+		try {
+			const row = createConflictRow({
+				item: makeItem(),
+				initialResolution: null,
+				initialExpanded: false,
+				onSelect: () => {},
+				onToggle: () => {},
+			});
+			expect(instances.length).toBe(0);
+			expect(() => row.disconnect()).not.toThrow();
+			expect(() => row.disconnect()).not.toThrow();
+		} finally {
+			globalThis.ResizeObserver = original;
+		}
+	});
 
+	test('ResizeObserver is created and observed when onHeightChange is provided; disconnect() invokes the observer', () => {
+		const instances: FakeObserver[] = [];
+		class FakeObserver {
+			observe = vi.fn();
+			unobserve = vi.fn();
+			disconnect = vi.fn();
+			constructor(public cb: ResizeObserverCallback) {
+				instances.push(this);
+			}
+		}
+		const original = globalThis.ResizeObserver;
+		globalThis.ResizeObserver = FakeObserver as unknown as typeof ResizeObserver;
+		try {
+			const row = createConflictRow({
+				item: makeItem({ path: 'notes/bar.md' }),
+				initialResolution: null,
+				initialExpanded: false,
+				onSelect: () => {},
+				onToggle: () => {},
+				onHeightChange: vi.fn(),
+			});
+			expect(instances.length).toBe(1);
+			expect(instances[0].observe).toHaveBeenCalledWith(row.el);
+			expect(instances[0].disconnect).not.toHaveBeenCalled();
+			row.disconnect();
+			expect(instances[0].disconnect).toHaveBeenCalledTimes(1);
+			row.disconnect();
+			expect(instances[0].disconnect).toHaveBeenCalledTimes(1);
+		} finally {
+			globalThis.ResizeObserver = original;
+		}
+	});
+
+	test('onHeightChange receives the row offsetHeight when ResizeObserver fires', () => {
 		const onHeightChange = vi.fn();
-		const rowWithObserver = createConflictRow({
-			item: makeItem({ path: 'notes/bar.md' }),
-			initialResolution: null,
-			initialExpanded: false,
-			onSelect: () => {},
-			onToggle: () => {},
-			onHeightChange,
-		});
-		expect(() => rowWithObserver.disconnect()).not.toThrow();
+		const instances: FakeObserver[] = [];
+		class FakeObserver {
+			observe = vi.fn();
+			unobserve = vi.fn();
+			disconnect = vi.fn();
+			constructor(public cb: () => void) {
+				instances.push(this);
+			}
+		}
+		const original = globalThis.ResizeObserver;
+		globalThis.ResizeObserver = FakeObserver as unknown as typeof ResizeObserver;
+		try {
+			const row = createConflictRow({
+				item: makeItem(),
+				initialResolution: null,
+				initialExpanded: false,
+				onSelect: () => {},
+				onToggle: () => {},
+				onHeightChange,
+			});
+			Object.defineProperty(row.el, 'offsetHeight', { configurable: true, get: () => 137 });
+			instances[0].cb();
+			expect(onHeightChange).toHaveBeenCalledWith(137);
+		} finally {
+			globalThis.ResizeObserver = original;
+		}
 	});
 
 	test('setContent replaces previous content rather than appending', () => {


### PR DESCRIPTION
## Summary
- Adds an optional `onHeightChange` callback + `ResizeObserver` to `createConflictRow`, plus a `disconnect()` method on the controller for unmount cleanup.
- Both modals now track a `measuredHeights` map per path; `getRowHeight` prefers the measured value and falls back to the existing `lines.length * LINE_HEIGHT_PX` estimate until the observer fires.
- Toggle-collapse clears the cached measurement so the estimate is used immediately and the observer corrects it on the next frame; rerenders are batched via `requestAnimationFrame` to avoid `ResizeObserver` loop warnings.
- Restores `white-space: pre-wrap; word-break: break-word; overflow-x: visible` on `.jackdaw-mobile .jackdaw-diff` so long diff lines wrap to fit a phone screen instead of scrolling horizontally — i.e. the stacked-unified layout §8.3 calls for.

Closes #112

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 272 tests pass (added one for `disconnect()` with and without `onHeightChange`)
- [x] `npm run build` succeeds
- [ ] Manual: reproduce the #110 scenario on Obsidian iOS — diff fits screen width, no horizontal scroll, row positions correct after expanding
- [ ] Manual: a conflict with a single very long line (200+ chars) on desktop — verify horizontal scroll still works under `pre`
- [ ] Manual: scroll a long conflict list up and down with rows that wrap differently — verify no jitter or row overlap as `ResizeObserver` updates fire
- [ ] Manual: collapse and re-expand rows on mobile — verify row positions stay correct
- [ ] Manual: re-test both modals (`ConflictResolutionModal` and `FirstSyncModal`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)