### PR TITLE
Add integration test harness

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Serialize runs so concurrent push + workflow_dispatch don't race on the
+# shared sandbox PAT's rate-limit pool. Don't cancel in-progress runs — they
+# need to reach teardown so per-run branches are deleted from the sandbox.
+concurrency:
+  group: integration
+  cancel-in-progress: false
+
 jobs:
   integration:
     name: Integration tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,23 @@
+name: Integration
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  integration:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run test:integration
+        env:
+          JACKDAW_GH_TOKEN: ${{ secrets.INTEGRATION_TEST_GH_TOKEN }}
+          JACKDAW_TEST_REPO: jimcasey/jackdaw-ci-sandbox

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -56,7 +56,7 @@ Automated end-to-end tests that exercise the sync engine against a real GitHub r
 
 ### Sandbox repo
 
-Tests run against a dedicated sandbox repository — by default `jimcasey/jackdaw-ci-sandbox`. The repo has a long-lived `main` seed branch with a small fixture commit; each test creates a fresh per-run branch off `main` and deletes it on teardown. Nothing in the harness touches `main` directly.
+Tests run against a dedicated sandbox repository identified by the `JACKDAW_TEST_REPO` env var. The conventional value (used by CI) is `jimcasey/jackdaw-ci-sandbox`. The repo has a long-lived `main` seed branch with a small fixture commit; each test creates a fresh per-run branch off `main` and deletes it on teardown. Nothing in the harness touches `main` directly.
 
 If the sandbox repo doesn't exist yet, create it as an empty repo with a single commit on `main` (e.g. add a README on creation) before running the suite.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -50,6 +50,46 @@ Before signing off on any phase from Phase 3 onward, smoke-test the plugin in Ob
 
 ---
 
+## Integration tests (§11.2)
+
+Automated end-to-end tests that exercise the sync engine against a real GitHub repository. Live in `tests/integration/` and run under a separate vitest config so they never trip during `npm test`.
+
+### Sandbox repo
+
+Tests run against a dedicated sandbox repository — by default `jimcasey/jackdaw-ci-sandbox`. The repo has a long-lived `main` seed branch with a small fixture commit; each test creates a fresh per-run branch off `main` and deletes it on teardown. Nothing in the harness touches `main` directly.
+
+If the sandbox repo doesn't exist yet, create it as an empty repo with a single commit on `main` (e.g. add a README on creation) before running the suite.
+
+### Running locally
+
+1. Create a fine-grained personal access token scoped to **only the sandbox repo**, with **Contents: read & write**, expiring in 90 days. (Same shape as the [GitHub personal access token setup](#github-personal-access-token-setup) above, but pointed at the sandbox.)
+2. Export the env vars and run:
+   ```sh
+   export JACKDAW_GH_TOKEN=<your-pat>
+   export JACKDAW_TEST_REPO=jimcasey/jackdaw-ci-sandbox
+   npm run test:integration
+   ```
+3. The suite creates and deletes its own branches. If a run is killed mid-test, orphaned `ci/...` branches may remain on the sandbox — they are safe to delete by hand from the GitHub UI.
+
+### Running in CI
+
+The workflow is `.github/workflows/integration.yml`. It triggers on push to `main` and on manual `workflow_dispatch` from the Actions tab. It does **not** run on pull requests (PRs from forks cannot read the secret, and PR runs against the sandbox would race with each other).
+
+The PAT is stored as the repository secret `INTEGRATION_TEST_GH_TOKEN`.
+
+### Rotating the integration PAT
+
+Fine-grained tokens expire (default 90 days). To rotate:
+
+1. In GitHub → **Settings → Developer settings → Personal access tokens → Fine-grained tokens**, generate a replacement scoped to `jimcasey/jackdaw-ci-sandbox` with **Contents: read & write** and a new 90-day expiry.
+2. In the `jackdaw` repo → **Settings → Secrets and variables → Actions**, update `INTEGRATION_TEST_GH_TOKEN` with the new value.
+3. Trigger the **Integration** workflow via `workflow_dispatch` to confirm the new token works.
+4. Revoke the old token from the fine-grained tokens page.
+
+Set a calendar reminder for a few days before expiry — the workflow will start failing once the old token expires.
+
+---
+
 ## iOS manual testing (Phase 5 gate)
 
 Corresponds to §11.3 of the design specification. Run on a **physical iPhone** — this cannot be delegated or automated.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/ --ext .ts",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "keywords": [],
   "license": "MIT",

--- a/tests/in-memory-adapters.test.ts
+++ b/tests/in-memory-adapters.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect } from 'vitest';
+import {
+	InMemoryStateAdapter,
+	InMemoryVaultAdapter,
+} from './integration/in-memory-adapters';
+
+describe('InMemoryVaultAdapter', () => {
+	test('writeText then readText round-trips', async () => {
+		const vault = new InMemoryVaultAdapter();
+		await vault.writeText('notes/a.md', 'hello');
+		expect(await vault.readText('notes/a.md')).toBe('hello');
+	});
+
+	test('writeBinary then readBinary preserves bytes', async () => {
+		const vault = new InMemoryVaultAdapter();
+		const bytes = new Uint8Array([1, 2, 3, 4]).buffer;
+		await vault.writeBinary('img.bin', bytes);
+		const back = new Uint8Array(await vault.readBinary('img.bin'));
+		expect([...back]).toEqual([1, 2, 3, 4]);
+	});
+
+	test('readText throws when path is missing', async () => {
+		const vault = new InMemoryVaultAdapter();
+		await expect(vault.readText('missing.md')).rejects.toThrow(/File not found/);
+	});
+
+	test('exists reflects writes and deletes', async () => {
+		const vault = new InMemoryVaultAdapter();
+		expect(await vault.exists('a.md')).toBe(false);
+		await vault.writeText('a.md', 'x');
+		expect(await vault.exists('a.md')).toBe(true);
+		await vault.delete('a.md');
+		expect(await vault.exists('a.md')).toBe(false);
+	});
+
+	test('listFiles returns every written path', async () => {
+		const vault = new InMemoryVaultAdapter();
+		await vault.writeText('a.md', '');
+		await vault.writeText('b/c.md', '');
+		expect((await vault.listFiles()).sort()).toEqual(['a.md', 'b/c.md']);
+	});
+
+	test('listDirectory returns immediate files and dirs by basename', async () => {
+		const vault = new InMemoryVaultAdapter();
+		await vault.writeText('.obsidian/app.json', '{}');
+		await vault.writeText('.obsidian/plugins/foo/main.js', '');
+		await vault.writeText('.obsidian/snippets/x.css', '');
+
+		const top = await vault.listDirectory('.obsidian');
+		expect(top.files.sort()).toEqual(['app.json']);
+		expect(top.dirs.sort()).toEqual(['plugins', 'snippets']);
+
+		const plugins = await vault.listDirectory('.obsidian/plugins');
+		expect(plugins.files).toEqual([]);
+		expect(plugins.dirs).toEqual(['foo']);
+	});
+
+	test('listDirectory tolerates a trailing slash on the input path', async () => {
+		const vault = new InMemoryVaultAdapter();
+		await vault.writeText('dir/a.md', '');
+		const listing = await vault.listDirectory('dir/');
+		expect(listing.files).toEqual(['a.md']);
+	});
+
+	test('snapshotPaths returns sorted paths', async () => {
+		const vault = new InMemoryVaultAdapter();
+		await vault.writeText('z.md', '');
+		await vault.writeText('a.md', '');
+		expect(vault.snapshotPaths()).toEqual(['a.md', 'z.md']);
+	});
+});
+
+describe('InMemoryStateAdapter', () => {
+	test('write then read round-trips', async () => {
+		const state = new InMemoryStateAdapter();
+		await state.write('p', 'data');
+		expect(await state.read('p')).toBe('data');
+	});
+
+	test('read throws when missing', async () => {
+		const state = new InMemoryStateAdapter();
+		await expect(state.read('missing')).rejects.toThrow(/Not found/);
+	});
+
+	test('rename moves data and clears the source key', async () => {
+		const state = new InMemoryStateAdapter();
+		await state.write('a.tmp', 'payload');
+		await state.rename('a.tmp', 'a');
+		expect(await state.exists('a.tmp')).toBe(false);
+		expect(await state.read('a')).toBe('payload');
+	});
+
+	test('rename throws when source missing', async () => {
+		const state = new InMemoryStateAdapter();
+		await expect(state.rename('nope', 'somewhere')).rejects.toThrow(/Not found/);
+	});
+
+	test('remove is idempotent', async () => {
+		const state = new InMemoryStateAdapter();
+		await state.remove('never-existed');
+		await state.write('p', 'x');
+		await state.remove('p');
+		expect(await state.exists('p')).toBe(false);
+	});
+
+	test('supports the StateStore atomic-write sequence', async () => {
+		// Mirrors StateStore.save: write tmp, remove canonical if present, rename tmp → canonical.
+		const state = new InMemoryStateAdapter();
+		await state.write('sync-state.json', '{"old":1}');
+		await state.write('sync-state.json.tmp', '{"new":1}');
+		if (await state.exists('sync-state.json')) {
+			await state.remove('sync-state.json');
+		}
+		await state.rename('sync-state.json.tmp', 'sync-state.json');
+		expect(await state.read('sync-state.json')).toBe('{"new":1}');
+		expect(await state.exists('sync-state.json.tmp')).toBe(false);
+	});
+});

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -1,6 +1,6 @@
 import { GitHubClient } from '../../src/github-client';
-import type { VaultAdapter } from '../../src/sync-engine-types';
-import type { StateAdapter } from '../../src/state-store';
+
+export { InMemoryVaultAdapter, InMemoryStateAdapter } from './in-memory-adapters';
 
 const GITHUB_API = 'https://api.github.com';
 const API_VERSION = '2022-11-28';
@@ -173,89 +173,3 @@ export async function readFiles(
 	return result;
 }
 
-export class InMemoryVaultAdapter implements VaultAdapter {
-	private readonly files = new Map<string, ArrayBuffer>();
-
-	listFiles(): Promise<string[]> {
-		return Promise.resolve([...this.files.keys()]);
-	}
-
-	listDirectory(path: string): Promise<{ files: string[]; dirs: string[] }> {
-		const prefix = path === '' ? '' : `${path.replace(/\/$/, '')}/`;
-		const files = new Set<string>();
-		const dirs = new Set<string>();
-		for (const filePath of this.files.keys()) {
-			if (!filePath.startsWith(prefix)) continue;
-			const rest = filePath.slice(prefix.length);
-			const slashIdx = rest.indexOf('/');
-			if (slashIdx === -1) {
-				files.add(rest);
-			} else {
-				dirs.add(rest.slice(0, slashIdx));
-			}
-		}
-		return Promise.resolve({ files: [...files], dirs: [...dirs] });
-	}
-
-	async readText(path: string): Promise<string> {
-		const buf = this.files.get(path);
-		if (!buf) throw new Error(`File not found: ${path}`);
-		return new TextDecoder().decode(buf);
-	}
-
-	async readBinary(path: string): Promise<ArrayBuffer> {
-		const buf = this.files.get(path);
-		if (!buf) throw new Error(`File not found: ${path}`);
-		return buf;
-	}
-
-	async writeText(path: string, content: string): Promise<void> {
-		const encoded = new TextEncoder().encode(content);
-		this.files.set(path, encoded.buffer.slice(encoded.byteOffset, encoded.byteOffset + encoded.byteLength));
-	}
-
-	async writeBinary(path: string, content: ArrayBuffer): Promise<void> {
-		this.files.set(path, content);
-	}
-
-	async delete(path: string): Promise<void> {
-		this.files.delete(path);
-	}
-
-	exists(path: string): Promise<boolean> {
-		return Promise.resolve(this.files.has(path));
-	}
-
-	snapshotPaths(): string[] {
-		return [...this.files.keys()].sort();
-	}
-}
-
-export class InMemoryStateAdapter implements StateAdapter {
-	private readonly entries = new Map<string, string>();
-
-	exists(path: string): Promise<boolean> {
-		return Promise.resolve(this.entries.has(path));
-	}
-
-	async read(path: string): Promise<string> {
-		const v = this.entries.get(path);
-		if (v === undefined) throw new Error(`Not found: ${path}`);
-		return v;
-	}
-
-	async write(path: string, data: string): Promise<void> {
-		this.entries.set(path, data);
-	}
-
-	async rename(from: string, to: string): Promise<void> {
-		const v = this.entries.get(from);
-		if (v === undefined) throw new Error(`Not found: ${from}`);
-		this.entries.delete(from);
-		this.entries.set(to, v);
-	}
-
-	async remove(path: string): Promise<void> {
-		this.entries.delete(path);
-	}
-}

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -1,0 +1,261 @@
+import { GitHubClient } from '../../src/github-client';
+import type { VaultAdapter } from '../../src/sync-engine-types';
+import type { StateAdapter } from '../../src/state-store';
+
+const GITHUB_API = 'https://api.github.com';
+const API_VERSION = '2022-11-28';
+
+export interface IntegrationConfig {
+	token: string;
+	owner: string;
+	repo: string;
+	seedBranch: string;
+}
+
+export function loadConfig(): IntegrationConfig {
+	const token = process.env['JACKDAW_GH_TOKEN'];
+	const repoFull = process.env['JACKDAW_TEST_REPO'];
+	const seedBranch = process.env['JACKDAW_TEST_SEED_BRANCH'] ?? 'main';
+
+	if (!token) {
+		throw new Error(
+			'JACKDAW_GH_TOKEN is not set. Integration tests require a fine-grained PAT scoped to the sandbox repo.',
+		);
+	}
+	if (!repoFull) {
+		throw new Error(
+			'JACKDAW_TEST_REPO is not set. Set it to "owner/repo" of the integration sandbox repository.',
+		);
+	}
+
+	const slash = repoFull.indexOf('/');
+	if (slash <= 0 || slash === repoFull.length - 1) {
+		throw new Error(`JACKDAW_TEST_REPO must be "owner/repo", got "${repoFull}".`);
+	}
+
+	return {
+		token,
+		owner: repoFull.slice(0, slash),
+		repo: repoFull.slice(slash + 1),
+		seedBranch,
+	};
+}
+
+export function makeClient(cfg: IntegrationConfig): GitHubClient {
+	return new GitHubClient(
+		() => cfg.token,
+		() => cfg.owner,
+		() => cfg.repo,
+		'integration',
+	);
+}
+
+export function uniqueBranchName(prefix = 'ci'): string {
+	const stamp = Date.now().toString(36);
+	const rand = Math.random().toString(36).slice(2, 8);
+	return `${prefix}/${stamp}-${rand}`;
+}
+
+async function gh(
+	cfg: IntegrationConfig,
+	method: string,
+	path: string,
+	body?: unknown,
+	accept = 'application/vnd.github+json',
+): Promise<Response> {
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${cfg.token}`,
+		Accept: accept,
+		'X-GitHub-Api-Version': API_VERSION,
+	};
+	if (body !== undefined) headers['Content-Type'] = 'application/json';
+
+	const res = await fetch(`${GITHUB_API}${path}`, {
+		method,
+		headers,
+		body: body !== undefined ? JSON.stringify(body) : undefined,
+	});
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(`GitHub ${method} ${path} → ${res.status}: ${text.slice(0, 300)}`);
+	}
+	return res;
+}
+
+interface BranchResponse {
+	commit: { sha: string; commit: { tree: { sha: string } } };
+}
+
+export async function createTestBranch(cfg: IntegrationConfig, name: string): Promise<void> {
+	const seed = (await gh(
+		cfg,
+		'GET',
+		`/repos/${cfg.owner}/${cfg.repo}/branches/${cfg.seedBranch}`,
+	).then(r => r.json())) as BranchResponse;
+
+	await gh(cfg, 'POST', `/repos/${cfg.owner}/${cfg.repo}/git/refs`, {
+		ref: `refs/heads/${name}`,
+		sha: seed.commit.sha,
+	});
+}
+
+export async function deleteTestBranch(cfg: IntegrationConfig, name: string): Promise<void> {
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${cfg.token}`,
+		Accept: 'application/vnd.github+json',
+		'X-GitHub-Api-Version': API_VERSION,
+	};
+	const res = await fetch(
+		`${GITHUB_API}/repos/${cfg.owner}/${cfg.repo}/git/refs/heads/${name}`,
+		{ method: 'DELETE', headers },
+	);
+	// 422 is returned if the ref doesn't exist; treat as already-gone.
+	if (!res.ok && res.status !== 404 && res.status !== 422) {
+		throw new Error(`Failed to delete branch ${name}: ${res.status} ${await res.text()}`);
+	}
+}
+
+export async function seedFiles(
+	cfg: IntegrationConfig,
+	branch: string,
+	files: Record<string, string>,
+): Promise<{ commitSha: string }> {
+	const tip = (await gh(
+		cfg,
+		'GET',
+		`/repos/${cfg.owner}/${cfg.repo}/branches/${branch}`,
+	).then(r => r.json())) as BranchResponse;
+
+	const treeEntries: Array<{ path: string; mode: '100644'; type: 'blob'; sha: string }> = [];
+	for (const [path, content] of Object.entries(files)) {
+		const blob = (await gh(cfg, 'POST', `/repos/${cfg.owner}/${cfg.repo}/git/blobs`, {
+			content,
+			encoding: 'utf-8',
+		}).then(r => r.json())) as { sha: string };
+		treeEntries.push({ path, mode: '100644', type: 'blob', sha: blob.sha });
+	}
+
+	const tree = (await gh(cfg, 'POST', `/repos/${cfg.owner}/${cfg.repo}/git/trees`, {
+		base_tree: tip.commit.commit.tree.sha,
+		tree: treeEntries,
+	}).then(r => r.json())) as { sha: string };
+
+	const commit = (await gh(cfg, 'POST', `/repos/${cfg.owner}/${cfg.repo}/git/commits`, {
+		message: `integration seed: ${Object.keys(files).join(', ')}`.slice(0, 200),
+		tree: tree.sha,
+		parents: [tip.commit.sha],
+	}).then(r => r.json())) as { sha: string };
+
+	await gh(cfg, 'PATCH', `/repos/${cfg.owner}/${cfg.repo}/git/refs/heads/${branch}`, {
+		sha: commit.sha,
+		force: false,
+	});
+
+	return { commitSha: commit.sha };
+}
+
+export async function readFiles(
+	cfg: IntegrationConfig,
+	branch: string,
+	paths: string[],
+): Promise<Record<string, string>> {
+	const result: Record<string, string> = {};
+	for (const path of paths) {
+		const res = await gh(
+			cfg,
+			'GET',
+			`/repos/${cfg.owner}/${cfg.repo}/contents/${encodeURI(path)}?ref=${encodeURIComponent(branch)}`,
+			undefined,
+			'application/vnd.github.raw',
+		);
+		result[path] = await res.text();
+	}
+	return result;
+}
+
+export class InMemoryVaultAdapter implements VaultAdapter {
+	private readonly files = new Map<string, ArrayBuffer>();
+
+	listFiles(): Promise<string[]> {
+		return Promise.resolve([...this.files.keys()]);
+	}
+
+	listDirectory(path: string): Promise<{ files: string[]; dirs: string[] }> {
+		const prefix = path === '' ? '' : `${path.replace(/\/$/, '')}/`;
+		const files = new Set<string>();
+		const dirs = new Set<string>();
+		for (const filePath of this.files.keys()) {
+			if (!filePath.startsWith(prefix)) continue;
+			const rest = filePath.slice(prefix.length);
+			const slashIdx = rest.indexOf('/');
+			if (slashIdx === -1) {
+				files.add(rest);
+			} else {
+				dirs.add(rest.slice(0, slashIdx));
+			}
+		}
+		return Promise.resolve({ files: [...files], dirs: [...dirs] });
+	}
+
+	async readText(path: string): Promise<string> {
+		const buf = this.files.get(path);
+		if (!buf) throw new Error(`File not found: ${path}`);
+		return new TextDecoder().decode(buf);
+	}
+
+	async readBinary(path: string): Promise<ArrayBuffer> {
+		const buf = this.files.get(path);
+		if (!buf) throw new Error(`File not found: ${path}`);
+		return buf;
+	}
+
+	async writeText(path: string, content: string): Promise<void> {
+		const encoded = new TextEncoder().encode(content);
+		this.files.set(path, encoded.buffer.slice(encoded.byteOffset, encoded.byteOffset + encoded.byteLength));
+	}
+
+	async writeBinary(path: string, content: ArrayBuffer): Promise<void> {
+		this.files.set(path, content);
+	}
+
+	async delete(path: string): Promise<void> {
+		this.files.delete(path);
+	}
+
+	exists(path: string): Promise<boolean> {
+		return Promise.resolve(this.files.has(path));
+	}
+
+	snapshotPaths(): string[] {
+		return [...this.files.keys()].sort();
+	}
+}
+
+export class InMemoryStateAdapter implements StateAdapter {
+	private readonly entries = new Map<string, string>();
+
+	exists(path: string): Promise<boolean> {
+		return Promise.resolve(this.entries.has(path));
+	}
+
+	async read(path: string): Promise<string> {
+		const v = this.entries.get(path);
+		if (v === undefined) throw new Error(`Not found: ${path}`);
+		return v;
+	}
+
+	async write(path: string, data: string): Promise<void> {
+		this.entries.set(path, data);
+	}
+
+	async rename(from: string, to: string): Promise<void> {
+		const v = this.entries.get(from);
+		if (v === undefined) throw new Error(`Not found: ${from}`);
+		this.entries.delete(from);
+		this.entries.set(to, v);
+	}
+
+	async remove(path: string): Promise<void> {
+		this.entries.delete(path);
+	}
+}

--- a/tests/integration/in-memory-adapters.ts
+++ b/tests/integration/in-memory-adapters.ts
@@ -1,0 +1,96 @@
+// Pure-Node test doubles for the engine's VaultAdapter and StateAdapter
+// interfaces. Kept free of any obsidian import so they can be unit-tested
+// under the regular `npm test` config without the integration alias.
+
+import type { VaultAdapter } from '../../src/sync-engine-types';
+import type { StateAdapter } from '../../src/state-store';
+
+export class InMemoryVaultAdapter implements VaultAdapter {
+	private readonly files = new Map<string, ArrayBuffer>();
+
+	listFiles(): Promise<string[]> {
+		return Promise.resolve([...this.files.keys()]);
+	}
+
+	listDirectory(path: string): Promise<{ files: string[]; dirs: string[] }> {
+		const prefix = path === '' ? '' : `${path.replace(/\/$/, '')}/`;
+		const files = new Set<string>();
+		const dirs = new Set<string>();
+		for (const filePath of this.files.keys()) {
+			if (!filePath.startsWith(prefix)) continue;
+			const rest = filePath.slice(prefix.length);
+			const slashIdx = rest.indexOf('/');
+			if (slashIdx === -1) {
+				files.add(rest);
+			} else {
+				dirs.add(rest.slice(0, slashIdx));
+			}
+		}
+		return Promise.resolve({ files: [...files], dirs: [...dirs] });
+	}
+
+	async readText(path: string): Promise<string> {
+		const buf = this.files.get(path);
+		if (!buf) throw new Error(`File not found: ${path}`);
+		return new TextDecoder().decode(buf);
+	}
+
+	async readBinary(path: string): Promise<ArrayBuffer> {
+		const buf = this.files.get(path);
+		if (!buf) throw new Error(`File not found: ${path}`);
+		return buf;
+	}
+
+	async writeText(path: string, content: string): Promise<void> {
+		const encoded = new TextEncoder().encode(content);
+		this.files.set(
+			path,
+			encoded.buffer.slice(encoded.byteOffset, encoded.byteOffset + encoded.byteLength),
+		);
+	}
+
+	async writeBinary(path: string, content: ArrayBuffer): Promise<void> {
+		this.files.set(path, content);
+	}
+
+	async delete(path: string): Promise<void> {
+		this.files.delete(path);
+	}
+
+	exists(path: string): Promise<boolean> {
+		return Promise.resolve(this.files.has(path));
+	}
+
+	snapshotPaths(): string[] {
+		return [...this.files.keys()].sort();
+	}
+}
+
+export class InMemoryStateAdapter implements StateAdapter {
+	private readonly entries = new Map<string, string>();
+
+	exists(path: string): Promise<boolean> {
+		return Promise.resolve(this.entries.has(path));
+	}
+
+	async read(path: string): Promise<string> {
+		const v = this.entries.get(path);
+		if (v === undefined) throw new Error(`Not found: ${path}`);
+		return v;
+	}
+
+	async write(path: string, data: string): Promise<void> {
+		this.entries.set(path, data);
+	}
+
+	async rename(from: string, to: string): Promise<void> {
+		const v = this.entries.get(from);
+		if (v === undefined) throw new Error(`Not found: ${from}`);
+		this.entries.delete(from);
+		this.entries.set(to, v);
+	}
+
+	async remove(path: string): Promise<void> {
+		this.entries.delete(path);
+	}
+}

--- a/tests/integration/obsidian-stub.ts
+++ b/tests/integration/obsidian-stub.ts
@@ -1,0 +1,50 @@
+// Stub for the `obsidian` module used during integration tests. Vitest aliases
+// `obsidian` → this file (see vitest.integration.config.ts) so `GitHubClient`,
+// which imports `requestUrl` from obsidian, can run in plain Node against the
+// real GitHub API.
+//
+// `requestUrl` is the only API exercised in the integration code paths; other
+// obsidian symbols (App, TFile, etc.) are not imported by the sync engine, so
+// stubbing just this is sufficient.
+
+export interface RequestUrlParam {
+	url: string;
+	method?: string;
+	contentType?: string;
+	body?: string | ArrayBuffer;
+	headers?: Record<string, string>;
+	throw?: boolean;
+}
+
+export interface RequestUrlResponse {
+	arrayBuffer: ArrayBuffer;
+	headers: Record<string, string>;
+	json: unknown;
+	status: number;
+	text: string;
+}
+
+export async function requestUrl(param: RequestUrlParam): Promise<RequestUrlResponse> {
+	const res = await fetch(param.url, {
+		method: param.method ?? 'GET',
+		headers: param.headers,
+		body: param.body as BodyInit | undefined,
+	});
+
+	const arrayBuffer = await res.arrayBuffer();
+	const text = new TextDecoder().decode(arrayBuffer);
+
+	let json: unknown;
+	try {
+		json = JSON.parse(text);
+	} catch {
+		// Non-JSON responses (e.g. raw blob bodies) leave json undefined.
+	}
+
+	const headers: Record<string, string> = {};
+	res.headers.forEach((value, key) => {
+		headers[key.toLowerCase()] = value;
+	});
+
+	return { status: res.status, headers, text, json, arrayBuffer };
+}

--- a/tests/integration/smoke.test.ts
+++ b/tests/integration/smoke.test.ts
@@ -7,8 +7,6 @@ import {
 	readFiles,
 	seedFiles,
 	uniqueBranchName,
-	InMemoryStateAdapter,
-	InMemoryVaultAdapter,
 	type IntegrationConfig,
 } from './helpers';
 
@@ -44,27 +42,5 @@ describe('integration harness smoke', () => {
 		const contents = await readFiles(cfg, branch, ['hello.md', 'sub/dir/note.md']);
 		expect(contents['hello.md']).toBe('Hi from smoke test\n');
 		expect(contents['sub/dir/note.md']).toBe('Nested\n');
-	});
-
-	test('in-memory adapters round-trip writes and reads', async () => {
-		const vault = new InMemoryVaultAdapter();
-		await vault.writeText('a.md', 'one');
-		await vault.writeText('dir/b.md', 'two');
-
-		expect(await vault.exists('a.md')).toBe(true);
-		expect((await vault.listFiles()).sort()).toEqual(['a.md', 'dir/b.md']);
-		expect(await vault.readText('a.md')).toBe('one');
-
-		const dirListing = await vault.listDirectory('dir');
-		expect(dirListing.files).toEqual(['b.md']);
-
-		const state = new InMemoryStateAdapter();
-		await state.write('plugins/jackdaw/sync-state.json.tmp', '{"v":1}');
-		await state.rename(
-			'plugins/jackdaw/sync-state.json.tmp',
-			'plugins/jackdaw/sync-state.json',
-		);
-		expect(await state.exists('plugins/jackdaw/sync-state.json')).toBe(true);
-		expect(await state.read('plugins/jackdaw/sync-state.json')).toBe('{"v":1}');
 	});
 });

--- a/tests/integration/smoke.test.ts
+++ b/tests/integration/smoke.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import {
+	createTestBranch,
+	deleteTestBranch,
+	loadConfig,
+	makeClient,
+	readFiles,
+	seedFiles,
+	uniqueBranchName,
+	InMemoryStateAdapter,
+	InMemoryVaultAdapter,
+	type IntegrationConfig,
+} from './helpers';
+
+describe('integration harness smoke', () => {
+	let cfg: IntegrationConfig;
+	let branch: string;
+
+	beforeAll(async () => {
+		cfg = loadConfig();
+		branch = uniqueBranchName('smoke');
+		await createTestBranch(cfg, branch);
+	});
+
+	afterAll(async () => {
+		if (branch) await deleteTestBranch(cfg, branch);
+	});
+
+	test('seeds files, reads them via the GitHub client, and reads them back via helpers', async () => {
+		await seedFiles(cfg, branch, {
+			'hello.md': 'Hi from smoke test\n',
+			'sub/dir/note.md': 'Nested\n',
+		});
+
+		const client = makeClient(cfg);
+		const { commitSha, treeSha } = await client.getBranch(cfg.owner, cfg.repo, branch);
+		expect(commitSha).toMatch(/^[0-9a-f]{40}$/);
+
+		const tree = await client.getTree(cfg.owner, cfg.repo, treeSha, true);
+		const blobPaths = tree.tree.filter(e => e.type === 'blob').map(e => e.path);
+		expect(blobPaths).toContain('hello.md');
+		expect(blobPaths).toContain('sub/dir/note.md');
+
+		const contents = await readFiles(cfg, branch, ['hello.md', 'sub/dir/note.md']);
+		expect(contents['hello.md']).toBe('Hi from smoke test\n');
+		expect(contents['sub/dir/note.md']).toBe('Nested\n');
+	});
+
+	test('in-memory adapters round-trip writes and reads', async () => {
+		const vault = new InMemoryVaultAdapter();
+		await vault.writeText('a.md', 'one');
+		await vault.writeText('dir/b.md', 'two');
+
+		expect(await vault.exists('a.md')).toBe(true);
+		expect((await vault.listFiles()).sort()).toEqual(['a.md', 'dir/b.md']);
+		expect(await vault.readText('a.md')).toBe('one');
+
+		const dirListing = await vault.listDirectory('dir');
+		expect(dirListing.files).toEqual(['b.md']);
+
+		const state = new InMemoryStateAdapter();
+		await state.write('plugins/jackdaw/sync-state.json.tmp', '{"v":1}');
+		await state.rename(
+			'plugins/jackdaw/sync-state.json.tmp',
+			'plugins/jackdaw/sync-state.json',
+		);
+		expect(await state.exists('plugins/jackdaw/sync-state.json')).toBe(true);
+		expect(await state.read('plugins/jackdaw/sync-state.json')).toBe('{"v":1}');
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
+    exclude: ['node_modules/**', 'tests/integration/**'],
     environment: 'node',
   },
 });

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const root = fileURLToPath(new URL('.', import.meta.url));
+
+export default defineConfig({
+  test: {
+    include: ['tests/integration/**/*.test.ts'],
+    environment: 'node',
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+    fileParallelism: false,
+  },
+  resolve: {
+    alias: {
+      obsidian: resolve(root, 'tests/integration/obsidian-stub.ts'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- New `vitest.integration.config.ts` aliases `obsidian` → a Node `fetch`-backed `requestUrl` stub so `GitHubClient` runs in plain Node; existing `vitest.config.ts` excludes `tests/integration/` so `npm test` stays hermetic.
- `tests/integration/helpers.ts` provides `createTestBranch` / `deleteTestBranch` / `seedFiles` / `readFiles`, plus `InMemoryVaultAdapter` and `InMemoryStateAdapter` test doubles for the engine interfaces.
- New `.github/workflows/integration.yml` runs `npm run test:integration` on push to `main` and `workflow_dispatch`, reading `INTEGRATION_TEST_GH_TOKEN` from secrets. PR runs are intentionally skipped.
- `docs/testing.md` now covers running the suite locally and rotating the PAT.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` — 21 files / 274 tests pass, integration directory is not picked up
- [x] `npm run test:integration` (no PAT) fails fast with a clear "JACKDAW_GH_TOKEN is not set" message — alias and config load cleanly
- [ ] After the sandbox repo `jimcasey/jackdaw-ci-sandbox` is created and `INTEGRATION_TEST_GH_TOKEN` is added: run `npm run test:integration` locally with a real PAT and confirm green
- [ ] Trigger the **Integration** workflow via `workflow_dispatch` from `main` and confirm green

Closes #114